### PR TITLE
fix: update CLI command from add-skill to skills for consistency (AI Assisted)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ A library of Agent Skills designed to work with the Stitch MCP server. Each skil
 
 ## Installation & Discovery
 
-Install any skill from this repository using the `add-skill` CLI. This command will automatically detect your active coding agents and place the skill in the appropriate directory.
+Install any skill from this repository using the `skills` CLI. This command will automatically detect your active coding agents and place the skill in the appropriate directory.
 
 ```bash
 # List all available skills in this repository
-npx add-skill google-labs-code/stitch-skills --list
+npx skills add google-labs-code/stitch-skills --list
 
 # Install a specific skill
-npx add-skill google-labs-code/stitch-skills --skill react:components --global
+npx skills add google-labs-code/stitch-skills --skill react:components --global
 ```
 
 ## Available Skills
@@ -20,28 +20,28 @@ npx add-skill google-labs-code/stitch-skills --skill react:components --global
 Analyzes Stitch projects and generates comprehensive `DESIGN.md` files documenting design systems in natural, semantic language optimized for Stitch screen generation.
 
 ```bash
-npx add-skill google-labs-code/stitch-skills --skill design-md --global
+npx skills add google-labs-code/stitch-skills --skill design-md --global
 ```
 
 ### react-components
 Converts Stitch screens to React component systems with automated validation and design token consistency.
 
 ```bash
-npx add-skill google-labs-code/stitch-skills --skill react:components --global
+npx skills add google-labs-code/stitch-skills --skill react:components --global
 ```
 
 ### stitch-loop
 Generates a complete multi-page website from a single prompt using Stitch, with automated file organization and validation.
 
 ```bash
-npx add-skill google-labs-code/stitch-skills --skill stitch-loop --global
+npx skills add google-labs-code/stitch-skills --skill stitch-loop --global
 ```
 
 ### enhance-prompt
 Transforms vague UI ideas into polished, Stitch-optimized prompts. Enhances specificity, adds UI/UX keywords, injects design system context, and structures output for better generation results.
 
 ```bash
-npx add-skill google-labs-code/stitch-skills --skill enhance-prompt --global
+npx skills add google-labs-code/stitch-skills --skill enhance-prompt --global
 ```
 
 ## Repository Structure


### PR DESCRIPTION
## Description

Updates all instances of the deprecated `npx add-skill` command to the new `npx skills add` command throughout the README.md documentation.

## Motivation

The `add-skill` CLI has been renamed to `skills`, and using the old command now displays a deprecation warning. This PR updates the documentation to reflect the current command structure and prevent user confusion.

## Changes

- Updated "Installation & Discovery" section to use `npx skills add`
- Updated all skill installation examples:
  - `design-md`
  - `react-components`
  - `stitch-loop`
  - `enhance-prompt`

## Example

**Before:**
```bash
npx add-skill google-labs-code/stitch-skills --skill react:components --global
```

**After**
```bash
npx skills add google-labs-code/stitch-skills --skill react:components --global
```


## Testing
 

- [x] Verified all command examples use the correct syntax
- [x]  Confirmed all flags and options remain the same


## Reference

- Official skills CLI: [https://github.com/vercel-labs/skills](https://github.com/vercel-labs/skills)
- Related deprecation notice appears when running npx add-skill