### PR TITLE
Revise installation commands in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stitch Agent Skills
 
-A library of Agent Skills designed to work with the Stitch MCP server. Each skill follows the Agent Skills open standard, for compatibility with coding agents such as Antigravity, Gemini CLI, Claude Code, Cursor.
+A library of Agent Skills designed to work with the Stitch MCP server. Each skill follows the Agent Skills open standard for compatibility with coding agents such as Antigravity, Gemini CLI, Claude Code, and Cursor.
 
 ## Installation & Discovery
 
@@ -8,10 +8,10 @@ Install any skill from this repository using the `add-skill` CLI. This command w
 
 ```bash
 # List all available skills in this repository
-npx add-skill google-labs-code/stitch-skills --list
+npx skills add google-labs-code/stitch-skills --list
 
 # Install a specific skill
-npx add-skill google-labs-code/stitch-skills --skill react:components --global
+npx skills add google-labs-code/stitch-skills --skill react:components --global
 ```
 
 ## Available Skills
@@ -20,28 +20,28 @@ npx add-skill google-labs-code/stitch-skills --skill react:components --global
 Analyzes Stitch projects and generates comprehensive `DESIGN.md` files documenting design systems in natural, semantic language optimized for Stitch screen generation.
 
 ```bash
-npx add-skill google-labs-code/stitch-skills --skill design-md --global
+npx skills add google-labs-code/stitch-skills --skill design-md --global
 ```
 
 ### react-components
 Converts Stitch screens to React component systems with automated validation and design token consistency.
 
 ```bash
-npx add-skill google-labs-code/stitch-skills --skill react:components --global
+npx skills add google-labs-code/stitch-skills --skill react:components --global
 ```
 
 ### stitch-loop
 Generates a complete multi-page website from a single prompt using Stitch, with automated file organization and validation.
 
 ```bash
-npx add-skill google-labs-code/stitch-skills --skill stitch-loop --global
+npx skills add google-labs-code/stitch-skills --skill stitch-loop --global
 ```
 
 ### enhance-prompt
 Transforms vague UI ideas into polished, Stitch-optimized prompts. Enhances specificity, adds UI/UX keywords, injects design system context, and structures output for better generation results.
 
 ```bash
-npx add-skill google-labs-code/stitch-skills --skill enhance-prompt --global
+npx skills add google-labs-code/stitch-skills --skill enhance-prompt --global
 ```
 
 ## Repository Structure


### PR DESCRIPTION
Updated installation commands in README to use 'skills' instead of 'add-skill'.

The command `add-skill` is deprecated and has been replaced by `skills add`.

<img width="808" height="180" alt="Screenshot 2026-02-01 at 18 17 35" src="https://github.com/user-attachments/assets/5926c592-9198-4ca5-8001-19e44f2bec3d" />

This PR fixes Issue https://github.com/google-labs-code/stitch-skills/issues/12
