### PR TITLE
docs: normalize skills install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npx skills add google-labs-code/stitch-skills --skill enhance-prompt --global
 Generates walkthrough videos from Stitch projects using Remotion with smooth transitions, zooming, and text overlays to showcase app screens professionally.
 
 ```bash
-npx add-skill google-labs-code/stitch-skills --skill remotion --global
+npx skills add google-labs-code/stitch-skills --skill remotion --global
 ```
 
 ### shadcn-ui

--- a/skills/design-md/README.md
+++ b/skills/design-md/README.md
@@ -3,7 +3,7 @@
 ## Install
 
 ```bash
-npx add-skill google-labs-code/stitch-skills --skill design-md --global
+npx skills add google-labs-code/stitch-skills --skill design-md --global
 ```
 
 ## Example Prompt

--- a/skills/enhance-prompt/README.md
+++ b/skills/enhance-prompt/README.md
@@ -3,7 +3,7 @@
 ## Install
 
 ```bash
-npx add-skill google-labs-code/stitch-skills --skill enhance-prompt --global
+npx skills add google-labs-code/stitch-skills --skill enhance-prompt --global
 ```
 
 ## Example Prompt

--- a/skills/react-components/README.md
+++ b/skills/react-components/README.md
@@ -3,7 +3,7 @@
 ## Install
 
 ```bash
-npx add-skill google-labs-code/stitch-skills --skill react:components --global
+npx skills add google-labs-code/stitch-skills --skill react:components --global
 ```
 
 ## Example Prompt

--- a/skills/remotion/README.md
+++ b/skills/remotion/README.md
@@ -43,7 +43,7 @@ This skill bridges Stitch (UI design platform) and Remotion (programmatic video 
 Install this skill using:
 
 ```bash
-npx add-skill google-labs-code/stitch-skills --skill remotion --global
+npx skills add google-labs-code/stitch-skills --skill remotion --global
 ```
 
 ## File Structure

--- a/skills/stitch-loop/README.md
+++ b/skills/stitch-loop/README.md
@@ -5,7 +5,7 @@ Teaches agents to iteratively build websites using Stitch with an autonomous bat
 ## Install
 
 ```bash
-npx add-skill google-labs-code/stitch-skills --skill stitch-loop --global
+npx skills add google-labs-code/stitch-skills --skill stitch-loop --global
 ```
 
 ## What It Does


### PR DESCRIPTION
## What
Standardizes install commands across documentation to use `npx skills add` consistently.

## Why
Keeps usage instructions aligned with the root README and avoids confusion from mixed CLI usage.

## Scope
- README.md
- skills/*/README.md (design-md, react-components, remotion, enhance-prompt, stitch-loop)

## Testing
Not applicable (docs only).