### PR TITLE
chore: improve devcontainer setup with stable volumes and gh cli feature

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "github@claude-plugins-official": true
+  }
+}

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -45,9 +45,9 @@ RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhisto
 ENV DEVCONTAINER=true
 
 # Create workspace and config directories and set permissions
-RUN mkdir -p /workspace /home/node/.claude && \
-  chown -R node:node /workspace /home/node/.claude
-
+RUN mkdir -p /workspace /home/node/.claude /home/node/.config/gh && \
+  chown -R node:node /workspace /home/node/.claude /home/node/.config/gh
+  
 WORKDIR /workspace
 
 ARG GIT_DELTA_VERSION=0.18.2

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,102 @@
+FROM node:25
+
+ARG TZ
+ENV TZ="$TZ"
+
+ARG CLAUDE_CODE_VERSION=latest
+
+# Install basic development tools and iptables/ipset
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  less \
+  git \
+  procps \
+  sudo \
+  fzf \
+  zsh \
+  man-db \
+  unzip \
+  gnupg2 \
+  gh \
+  iptables \
+  ipset \
+  iproute2 \
+  dnsutils \
+  aggregate \
+  jq \
+  nano \
+  vim \
+  python3-pip \
+  python3.11-venv \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Ensure default node user has access to /usr/local/share
+RUN mkdir -p /usr/local/share/npm-global && \
+  chown -R node:node /usr/local/share
+
+ARG USERNAME=node
+
+# Persist bash history.
+RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+  && mkdir /commandhistory \
+  && touch /commandhistory/.bash_history \
+  && chown -R $USERNAME /commandhistory
+
+# Set `DEVCONTAINER` environment variable to help with orientation
+ENV DEVCONTAINER=true
+
+# Create workspace and config directories and set permissions
+RUN mkdir -p /workspace /home/node/.claude && \
+  chown -R node:node /workspace /home/node/.claude
+
+WORKDIR /workspace
+
+ARG GIT_DELTA_VERSION=0.18.2
+RUN ARCH=$(dpkg --print-architecture) && \
+  wget "https://github.com/dandavison/delta/releases/download/${GIT_DELTA_VERSION}/git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" && \
+  sudo dpkg -i "git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" && \
+  rm "git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb"
+
+# Set up non-root user
+USER node
+
+# Install global packages
+ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
+ENV PATH=$PATH:/usr/local/share/npm-global/bin
+
+# Set the default shell to zsh rather than sh
+ENV SHELL=/bin/zsh
+
+# Set the default editor and visual
+ENV EDITOR=nano
+ENV VISUAL=nano
+
+# Default powerline10k theme
+ARG ZSH_IN_DOCKER_VERSION=1.2.0
+RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/v${ZSH_IN_DOCKER_VERSION}/zsh-in-docker.sh)" -- \
+  -p git \
+  -p fzf \
+  -a "source /usr/share/doc/fzf/examples/key-bindings.zsh" \
+  -a "source /usr/share/doc/fzf/examples/completion.zsh" \
+  -a "export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+  -a "export PATH=\"$HOME/.local/bin:$PATH\""\
+  -x
+
+# Install Claude
+# RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
+RUN curl -fsSL https://claude.ai/install.sh | bash
+# Install Gemini CLI
+RUN npm install -g @google/gemini-cli
+
+# Install Pi Coding Agent
+RUN npm install -g @mariozechner/pi-coding-agent
+
+# Install GitHub Copilot CLI
+RUN npm install -g @github/copilot
+
+# Copy and set up firewall script
+# COPY init-firewall.sh /usr/local/bin/
+# USER root
+# RUN chmod +x /usr/local/bin/init-firewall.sh && \
+#   echo "node ALL=(root) NOPASSWD: /usr/local/bin/init-firewall.sh" > /etc/sudoers.d/node-firewall && \
+#   chmod 0440 /etc/sudoers.d/node-firewall
+USER node

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,67 @@
+{
+  "name": "Agent Sandbox - ${localWorkspaceFolder}",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "TZ": "${localEnv:TZ:America/Chicago}",
+      "CLAUDE_CODE_VERSION": "latest",
+      "GIT_DELTA_VERSION": "0.18.2",
+      "ZSH_IN_DOCKER_VERSION": "1.2.0"
+    }
+  },
+  "runArgs": ["--cap-add=NET_ADMIN", "--cap-add=NET_RAW"],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "anthropic.claude-code",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        // "eamodio.gitlens",
+        // "GoogleCloudTools.cloudcode",
+        // "Google.geminicodeassist",
+        // "google.gemini-cli-vscode-ide-companion",
+        "Bhsd.vscode-extension-wikiparser",
+        "RoweWilsonFrederiskHolme.wikitext",
+        "bierner.markdown-mermaid"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.codeActionsOnSave": {
+          "source.fixAll.eslint": "explicit"
+        },
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "terminal.integrated.profiles.linux": {
+          "bash": {
+            "path": "bash",
+            "icon": "terminal-bash"
+          },
+          "zsh": {
+            "path": "zsh"
+          }
+        }
+      }
+    }
+  },
+  "remoteUser": "node",
+  "mounts": [
+    "source=claude-code-config-${devcontainerId},target=/home/node/.claude,type=volume",
+    "source=claude-code-gh-${devcontainerId},target=/home/node/.config/gh,type=volume",
+    "source=${localEnv:HOME}/.gitconfig,target=/home/node/.gitconfig,type=bind,readonly",
+    "source=${localWorkspaceFolder}/.devcontainer,target=/workspace/.devcontainer,type=bind,readonly"
+    // "source=${localEnv:HOME}${localEnv:USERPROFILE}/.claude,target=/home/node/.claude,type=bind",
+    // "source=${localEnv:HOME}${localEnv:USERPROFILE}/.gemini,target=/home/node/.gemini,type=bind",
+    // "source=${localEnv:HOME}${localEnv:USERPROFILE}/.copilot,target=/home/node/.copilot,type=bind"
+  ],
+  "containerEnv": {
+    "NODE_OPTIONS": "--max-old-space-size=4096",
+    "CLAUDE_CONFIG_DIR": "/home/node/.claude",
+    "POWERLEVEL9K_DISABLE_GITSTATUS": "true",
+    "PI_CODING_AGENT_DIR": "/workspace/.pi/agent"
+    // "PI_PACKAGE_DIR": "/workspace/.pi/agent"
+  },
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
+  "workspaceFolder": "/workspace"
+  // "postStartCommand": "sudo /usr/local/bin/init-firewall.sh",
+  // "waitFor": "postStartCommand"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,6 +9,10 @@
       "ZSH_IN_DOCKER_VERSION": "1.2.0"
     }
   },
+  "features": {
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
   "runArgs": ["--cap-add=NET_ADMIN", "--cap-add=NET_RAW"],
   "customizations": {
     "vscode": {
@@ -16,7 +20,6 @@
         "anthropic.claude-code",
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
-        // "eamodio.gitlens",
         // "GoogleCloudTools.cloudcode",
         // "Google.geminicodeassist",
         // "google.gemini-cli-vscode-ide-companion",
@@ -45,10 +48,13 @@
   },
   "remoteUser": "node",
   "mounts": [
-    "source=claude-code-config-${devcontainerId},target=/home/node/.claude,type=volume",
-    "source=claude-code-gh-${devcontainerId},target=/home/node/.config/gh,type=volume",
+    "source=claude-code-config-homedev,target=/home/node/.claude,type=volume",
+    "source=claude-code-gh-homedev,target=/home/node/.config/gh,type=volume",
+    // "source=${localEnv:HOME}/.claude,target=/home/node/.claude,type=bind",
+    // "source=${localEnv:HOME}/.config/gh,target=/home/node/.config/gh,type=bind",
     "source=${localEnv:HOME}/.gitconfig,target=/home/node/.gitconfig,type=bind,readonly",
-    "source=${localWorkspaceFolder}/.devcontainer,target=/workspace/.devcontainer,type=bind,readonly"
+    "source=${localWorkspaceFolder}/.devcontainer,target=/workspace/.devcontainer,type=bind"
+    // ,readonly"
     // "source=${localEnv:HOME}${localEnv:USERPROFILE}/.claude,target=/home/node/.claude,type=bind",
     // "source=${localEnv:HOME}${localEnv:USERPROFILE}/.gemini,target=/home/node/.gemini,type=bind",
     // "source=${localEnv:HOME}${localEnv:USERPROFILE}/.copilot,target=/home/node/.copilot,type=bind"

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+set -euo pipefail  # Exit on error, undefined vars, and pipeline failures
+IFS=$'\n\t'       # Stricter word splitting
+
+# 1. Extract Docker DNS info BEFORE any flushing
+DOCKER_DNS_RULES=$(iptables-save -t nat | grep "127\.0\.0\.11" || true)
+
+# Flush existing rules and delete existing ipsets
+iptables -F
+iptables -X
+iptables -t nat -F
+iptables -t nat -X
+iptables -t mangle -F
+iptables -t mangle -X
+ipset destroy allowed-domains 2>/dev/null || true
+
+# 2. Selectively restore ONLY internal Docker DNS resolution
+if [ -n "$DOCKER_DNS_RULES" ]; then
+    echo "Restoring Docker DNS rules..."
+    iptables -t nat -N DOCKER_OUTPUT 2>/dev/null || true
+    iptables -t nat -N DOCKER_POSTROUTING 2>/dev/null || true
+    echo "$DOCKER_DNS_RULES" | xargs -L 1 iptables -t nat
+else
+    echo "No Docker DNS rules to restore"
+fi
+
+# First allow DNS and localhost before any restrictions
+# Allow outbound DNS
+iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
+# Allow inbound DNS responses
+iptables -A INPUT -p udp --sport 53 -j ACCEPT
+# Allow outbound SSH
+iptables -A OUTPUT -p tcp --dport 22 -j ACCEPT
+# Allow inbound SSH responses
+iptables -A INPUT -p tcp --sport 22 -m state --state ESTABLISHED -j ACCEPT
+# Allow localhost
+iptables -A INPUT -i lo -j ACCEPT
+iptables -A OUTPUT -o lo -j ACCEPT
+
+# Create ipset with CIDR support
+ipset create allowed-domains hash:net
+
+# Fetch Google information and aggregate + add their IP ranges
+echo "Fetching Google IP ranges..."
+google_ranges=$(curl -s https://www.gstatic.com/ipranges/goog.json)
+if [ -z "$google_ranges" ]; then
+    echo "ERROR: Failed to fetch Google IP ranges"
+    exit 1
+fi
+
+if ! echo "$google_ranges" | jq -e '.prefixes and .prefixes[0].ipv4Prefix' >/dev/null; then
+    echo "ERROR: Google API response missing required fields"
+    exit 1
+fi
+echo "Processing Google IPs..."
+while read -r cidr; do
+    if [[ ! "$cidr" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$ ]]; then
+        echo "ERROR: Invalid CIDR range from Google meta: $cidr"
+        exit 1
+    fi
+    echo "Adding Google range $cidr"
+    ipset -exist add allowed-domains "$cidr"
+done < <(echo "$google_ranges" | jq -r '.prefixes[].ipv4Prefix' | aggregate -q)
+
+# Fetch GitHub meta information and aggregate + add their IP ranges
+echo "Fetching GitHub IP ranges..."
+gh_ranges=$(curl -s https://api.github.com/meta)
+if [ -z "$gh_ranges" ]; then
+    echo "ERROR: Failed to fetch GitHub IP ranges"
+    exit 1
+fi
+
+if ! echo "$gh_ranges" | jq -e '.web and .api and .git' >/dev/null; then
+    echo "ERROR: GitHub API response missing required fields"
+    exit 1
+fi
+
+echo "Processing GitHub IPs..."
+while read -r cidr; do
+    if [[ ! "$cidr" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$ ]]; then
+        echo "ERROR: Invalid CIDR range from GitHub meta: $cidr"
+        exit 1
+    fi
+    echo "Adding GitHub range $cidr"
+    ipset -exist add allowed-domains "$cidr"
+done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
+
+# Resolve and add other allowed domains
+for domain in \
+    "registry.npmjs.org" \
+    "oauth2.googleapis.com" \
+    "api.anthropic.com" \
+    "sentry.io" \
+    "statsig.anthropic.com" \
+    "statsig.com" \
+    "marketplace.visualstudio.com" \
+    "vscode.blob.core.windows.net" \
+    "update.code.visualstudio.com"; do
+    echo "Resolving $domain..."
+    ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}')
+    if [ -z "$ips" ]; then
+        echo "ERROR: Failed to resolve $domain"
+        exit 1
+    fi
+    
+    while read -r ip; do
+        if [[ ! "$ip" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            echo "ERROR: Invalid IP from DNS for $domain: $ip"
+            exit 1
+        fi
+        echo "Adding $ip for $domain"
+        ipset -exist add allowed-domains "$ip"
+    done < <(echo "$ips")
+done
+
+# Get host IP from default route
+HOST_IP=$(ip route | grep default | cut -d" " -f3)
+if [ -z "$HOST_IP" ]; then
+    echo "ERROR: Failed to detect host IP"
+    exit 1
+fi
+
+HOST_NETWORK=$(echo "$HOST_IP" | sed "s/\.[0-9]*$/.0\/24/")
+echo "Host network detected as: $HOST_NETWORK"
+
+# Set up remaining iptables rules
+iptables -A INPUT -s "$HOST_NETWORK" -j ACCEPT
+iptables -A OUTPUT -d "$HOST_NETWORK" -j ACCEPT
+
+# Set default policies to DROP first
+iptables -P INPUT DROP
+iptables -P FORWARD DROP
+iptables -P OUTPUT DROP
+
+# First allow established connections for already approved traffic
+iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+# Then allow only specific outbound traffic to allowed domains
+iptables -A OUTPUT -m set --match-set allowed-domains dst -j ACCEPT
+
+# Explicitly REJECT all other outbound traffic for immediate feedback
+iptables -A OUTPUT -j REJECT --reject-with icmp-admin-prohibited
+
+echo "Firewall configuration complete"
+echo "Verifying firewall rules..."
+if curl --connect-timeout 5 https://example.com >/dev/null 2>&1; then
+    echo "ERROR: Firewall verification failed - was able to reach https://example.com"
+    exit 1
+else
+    echo "Firewall verification passed - unable to reach https://example.com as expected"
+fi
+
+# Verify GitHub API access
+if ! curl --connect-timeout 5 https://api.github.com/zen >/dev/null 2>&1; then
+    echo "ERROR: Firewall verification failed - unable to reach https://api.github.com"
+    exit 1
+else
+    echo "Firewall verification passed - able to reach https://api.github.com as expected"
+fi

--- a/skills/swiftui-loop/README.md
+++ b/skills/swiftui-loop/README.md
@@ -1,0 +1,55 @@
+# SwiftUI Build Loop Skill
+
+Teaches agents to iteratively build iOS SwiftUI views using Stitch mobile mockups with an autonomous baton-passing loop pattern.
+
+## Install
+
+```bash
+npx skills add google-labs-code/stitch-skills --skill swiftui-loop --global
+```
+
+## What It Does
+
+Enables continuous, autonomous iOS view development through a "baton" system:
+
+1. Agent reads task from `next-prompt.md`
+2. Generates mobile screen mockup via Stitch MCP tools
+3. Translates the mockup into a SwiftUI `View` (`.swift`)
+4. Integrates view into the app's navigation structure
+5. Writes next task to continue the loop
+
+## Prerequisites
+
+- Stitch MCP Server access
+- A `DESIGN.md` file (generate with the `design-md` skill, then extend with SwiftUI tokens)
+- An `APP.md` file for project context
+
+## Example Prompt
+
+```text
+Read my next-prompt.md and generate the SwiftUI view using Stitch, then prepare the next iteration.
+```
+
+## Skill Structure
+
+```
+swiftui-loop/
+├── SKILL.md                    — Core pattern instructions
+├── README.md                   — This file
+├── resources/
+│   ├── baton-schema.md         — Baton file format spec
+│   └── app-template.md         — APP.md and DESIGN.md templates for SwiftUI
+└── examples/
+    ├── next-prompt.md           — Example baton
+    └── APP.md                   — Example app constitution
+```
+
+## Works With
+
+- **`design-md` skill**: Generate `DESIGN.md` from existing Stitch screens, then extend with SwiftUI tokens
+- **CI/CD**: GitHub Actions can trigger new iterations on push
+- **Agent chains**: Dispatch to other agents (Jules, etc.)
+
+## Learn More
+
+See [SKILL.md](./SKILL.md) for complete instructions.

--- a/skills/swiftui-loop/SKILL.md
+++ b/skills/swiftui-loop/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: swiftui-loop
+description: Teaches agents to iteratively build iOS SwiftUI views using Stitch mockups with an autonomous baton-passing loop pattern
+allowed-tools:
+  - "stitch*:*"
+  - "Read"
+  - "Write"
+  - "Bash"
+---
+
+# SwiftUI Build Loop
+
+You are an **autonomous iOS frontend builder** participating in an iterative view-building loop. Your goal is to generate a mobile screen mockup using Stitch, translate it into a SwiftUI `View`, integrate it into the app, and prepare instructions for the next iteration.
+
+## Overview
+
+The Build Loop pattern enables continuous, autonomous iOS app development through a "baton" system. Each iteration:
+1. Reads the current task from a baton file (`next-prompt.md`)
+2. Generates a mobile screen mockup using Stitch MCP tools
+3. Translates the mockup into a SwiftUI `View` (`.swift` file)
+4. Integrates the view into the app structure
+5. Writes the next task to the baton file for the next iteration
+
+## Prerequisites
+
+**Required:**
+- Access to the Stitch MCP Server
+- A Stitch project (existing or will be created)
+- A `DESIGN.md` file (generate one using the `design-md` skill if needed)
+- An `APP.md` file documenting the app vision and view inventory
+
+## The Baton System
+
+The `next-prompt.md` file acts as a relay baton between iterations:
+
+```markdown
+---
+view: ProfileView
+---
+A user profile screen for a fitness tracking app.
+
+**DESIGN SYSTEM (REQUIRED):**
+[Copy from DESIGN.md Section 6]
+
+**Screen Structure:**
+1. Avatar and display name at top
+2. Stats row: workouts, streak, calories
+3. Recent activity list
+4. Settings button in navigation bar
+```
+
+**Critical rules:**
+- The `view` field in YAML frontmatter determines the Swift filename (e.g. `ProfileView` → `ProfileView.swift`)
+- The view name must be a valid Swift type name (PascalCase, no spaces)
+- The prompt content must include the design system block from `DESIGN.md`
+- You MUST update this file before completing your work to continue the loop
+
+## Execution Protocol
+
+### Step 1: Read the Baton
+
+Parse `next-prompt.md` to extract:
+- **View name** from the `view` frontmatter field (e.g. `ProfileView`)
+- **Prompt content** from the markdown body
+
+### Step 2: Consult Context Files
+
+Before generating, read these files:
+
+| File | Purpose |
+|------|---------|
+| `APP.md` | App vision, **Stitch Project ID**, existing views inventory, navigation structure, roadmap |
+| `DESIGN.md` | Required visual style for Stitch prompts and SwiftUI design tokens |
+
+**Important checks:**
+- Section 4 (View Inventory) — Do NOT recreate views that already exist
+- Section 5 (Roadmap) — Pick tasks from here if backlog exists
+- Section 6 (Creative Freedom) — Ideas for new views if roadmap is empty
+
+### Step 3: Generate Mockup with Stitch
+
+Use the Stitch MCP tools to generate a mobile screen mockup:
+
+1. **Discover namespace**: Run `list_tools` to find the Stitch MCP prefix
+2. **Get or create project**:
+   - If `stitch.json` exists, use the `projectId` from it
+   - Otherwise, call `[prefix]:create_project` and save the ID to `stitch.json`
+3. **Generate screen**: Call `[prefix]:generate_screen_from_text` with:
+   - `projectId`: The project ID
+   - `prompt`: The full prompt from the baton (including design system block)
+   - `deviceType`: `MOBILE` (default) or as specified in the baton
+4. **Retrieve assets**: Call `[prefix]:get_screen` to get:
+   - `screenshot.downloadUrl` — Download and save as `queue/{ViewName}.png` (visual reference)
+   - `htmlCode.downloadUrl` — Download and save as `queue/{ViewName}.html` (layout/spacing reference)
+
+### Step 4: Translate to SwiftUI
+
+Using the Stitch screenshot and HTML as your visual reference, write a complete SwiftUI view to `queue/{ViewName}.swift`:
+
+1. **Reproduce the layout faithfully**: Match the visual hierarchy, spacing, and component arrangement from the mockup
+2. **Apply SwiftUI design tokens** from `DESIGN.md` Section 6:
+   - Colors: `Color("AccentColor")`, `Color(hex:)`, or `.primary`/`.secondary`
+   - Fonts: `.font(.headline)`, `.font(.custom(...))`, `.fontWeight()`
+   - Corner radius, padding, and spacing values
+   - SF Symbols names for icons
+3. **Use idiomatic SwiftUI**:
+   - `VStack`, `HStack`, `ZStack`, `LazyVStack`, `LazyHGrid` for layout
+   - `List` or `ScrollView` for scrollable content
+   - `NavigationLink` for drill-down navigation
+   - `@State`, `@Binding`, `@ObservedObject` for state as appropriate
+   - `.toolbar` and `ToolbarItem` for navigation bar buttons
+   - `AsyncImage` for remote images
+4. **Include a `#Preview`** macro at the bottom for Xcode Previews
+5. **Keep the view self-contained** with sensible placeholder/mock data
+
+Example output structure:
+```swift
+import SwiftUI
+
+struct ProfileView: View {
+    var body: some View {
+        // ...
+    }
+}
+
+#Preview {
+    ProfileView()
+}
+```
+
+### Step 5: Integrate into App
+
+1. Move generated Swift file from `queue/{ViewName}.swift` to `Sources/Views/{ViewName}.swift`
+2. Wire navigation:
+   - Add a `NavigationLink` to the new view from its logical parent
+   - If it belongs in the root `TabView`, add a new tab entry in `ContentView.swift`
+   - Replace any placeholder `NavigationLink(destination: EmptyView())` stubs
+3. Ensure the view is reachable from the existing navigation graph
+
+### Step 6: Update App Documentation
+
+Modify `APP.md`:
+- Add the new view to Section 4 (View Inventory) with `[x]`
+- Remove any idea you consumed from Section 6 (Creative Freedom)
+- Update Section 5 (Roadmap) if you completed a backlog item
+
+### Step 7: Prepare the Next Baton (Critical)
+
+**You MUST update `next-prompt.md` before completing.** This keeps the loop alive.
+
+1. **Decide the next view**:
+   - Check `APP.md` Section 5 (Roadmap) for pending items
+   - If empty, pick from Section 6 (Creative Freedom)
+   - Or invent something new that fits the app vision
+2. **Write the baton** with proper YAML frontmatter:
+
+```markdown
+---
+view: SettingsView
+---
+A settings screen with grouped options for account, notifications, and privacy.
+
+**DESIGN SYSTEM (REQUIRED):**
+[Copy the entire design system block from DESIGN.md]
+
+**Screen Structure:**
+1. Navigation bar with "Settings" title
+2. Grouped list: Account section (profile, password)
+3. Grouped list: Notifications section (push, email toggles)
+4. Grouped list: About section (version, privacy policy link)
+```
+
+## File Structure Reference
+
+```
+project/
+├── next-prompt.md          # The baton — current task
+├── stitch.json             # Stitch project ID (persist this!)
+├── DESIGN.md               # Visual design system (from design-md skill)
+├── APP.md                  # App vision, view inventory, roadmap
+├── queue/                  # Staging area for generated output
+│   ├── {ViewName}.png      # Stitch screenshot (visual reference)
+│   ├── {ViewName}.html     # Stitch HTML (layout reference)
+│   └── {ViewName}.swift    # Generated SwiftUI view (before integration)
+└── Sources/Views/          # Integrated SwiftUI views
+    ├── ContentView.swift
+    └── {ViewName}.swift
+```
+
+## Orchestration Options
+
+The loop can be driven by different orchestration layers:
+
+| Method | How it works |
+|--------|--------------|
+| **CI/CD** | GitHub Actions triggers on `next-prompt.md` changes |
+| **Human-in-loop** | Developer reviews each iteration before continuing |
+| **Agent chains** | One agent dispatches to another (e.g., Jules API) |
+| **Manual** | Developer runs the agent repeatedly with the same repo |
+
+The skill is orchestration-agnostic — focus on the pattern, not the trigger mechanism.
+
+## Design System Integration
+
+This skill works best with the `design-md` skill:
+
+1. **First time setup**: Generate `DESIGN.md` using the `design-md` skill from an existing Stitch screen, then extend Section 6 with SwiftUI-specific tokens (see `resources/app-template.md`)
+2. **Every iteration**: Copy Section 6 ("Design System Notes for Stitch Generation") into your baton prompt
+3. **Consistency**: All generated views will share the same visual language
+
+## Common Pitfalls
+
+- ❌ Forgetting to update `next-prompt.md` (breaks the loop)
+- ❌ Recreating a view that already exists in the view inventory
+- ❌ Not including the design system block in the Stitch prompt
+- ❌ Using `deviceType: DESKTOP` — always use `MOBILE` for iOS views
+- ❌ Leaving placeholder `NavigationLink(destination: EmptyView())` instead of wiring real navigation
+- ❌ Forgetting to persist `stitch.json` after creating a new project
+- ❌ Writing UIKit code instead of SwiftUI
+- ❌ Missing `#Preview` macro (breaks Xcode Previews)
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Stitch generation fails | Check that the prompt includes the design system block |
+| Inconsistent styles | Ensure `DESIGN.md` is up-to-date and copied correctly |
+| Loop stalls | Verify `next-prompt.md` was updated with valid frontmatter |
+| SwiftUI compile error | Check that all referenced types and assets exist in the project |
+| Navigation broken | Verify the view is reachable from `ContentView` or the relevant parent |
+| View looks nothing like mockup | Re-examine the Stitch screenshot in `queue/` and adjust layout/colors |

--- a/skills/swiftui-loop/examples/APP.md
+++ b/skills/swiftui-loop/examples/APP.md
@@ -1,0 +1,79 @@
+---
+stitch-project-id: 13534454087919359824
+---
+# App Vision & Constitution
+
+> **AGENT INSTRUCTION:** Read this file before every iteration. It serves as the project's "Long-Term Memory." If `next-prompt.md` is empty, pick the highest priority item from Section 5 OR invent a new view that fits the app vision.
+
+## 1. Core Identity
+* **App Name:** FitTrack
+* **Bundle ID:** `com.example.fittrack`
+* **Stitch Project ID:** `13534454087919359824`
+* **Mission:** A personal fitness tracking app that helps users log workouts, visualize progress, and stay motivated.
+* **Target Audience:** Fitness enthusiasts, gym-goers, and anyone building an active lifestyle.
+* **Voice:** Energetic, motivating, clean, and data-forward.
+* **Platform:** iOS 17+
+
+## 2. Visual Language (Stitch Prompt Strategy)
+*Strictly adhere to these descriptive rules when prompting Stitch. Do NOT use code.*
+
+* **The "Vibe" (Adjectives):**
+    * *Primary:* **Energetic** (Bold typography, strong contrast, action-oriented).
+    * *Secondary:* **Clean** (Generous whitespace, minimal chrome, content-first).
+    * *Tertiary:* **Data-forward** (Numbers and stats are heroes, clear hierarchy).
+
+* **Color Philosophy (Semantic):**
+    * **Backgrounds:** System background (near-black #1C1C1E in dark mode).
+    * **Accents:** Vibrant electric blue (#007AFF) for CTAs and highlights.
+    * **Text:** Primary white (#FFFFFF) for headlines, secondary gray (#8E8E93) for supporting text.
+
+## 3. Architecture & Navigation
+* **Root Navigation:** TabView with 4 tabs
+* **Tab Structure:**
+    * Tab 1: Home (house.fill) → `HomeView`
+    * Tab 2: Workouts (figure.strengthtraining.traditional) → `WorkoutsView`
+    * Tab 3: Progress (chart.line.uptrend.xyaxis) → `ProgressView`
+    * Tab 4: Profile (person.fill) → `ProfileView`
+* **Sources Directory:** `Sources/Views/`
+* **Asset Flow:** Stitch generates to `queue/` → Validate → Move to `Sources/Views/`
+
+## 4. View Inventory (Current State)
+*The Agent MUST update this section when a new view is successfully integrated.*
+
+* [x] `ContentView` - Root TabView container with 4 tabs
+* [x] `HomeView` - Dashboard with today's summary and quick-start workout button
+* [ ] `WorkoutsView` - Browsable list of workout templates
+* [ ] `ProgressView` - Charts and stats for workout history
+* [ ] `ProfileView` - User profile, stats summary, and settings shortcut
+
+## 5. The Roadmap (Backlog)
+*If `next-prompt.md` is empty or completed, pick the next task from here.*
+
+### High Priority
+- [ ] **WorkoutsView:** Browsable list of workout templates grouped by muscle group.
+- [ ] **WorkoutDetailView:** Drill-down view showing exercises, sets, and reps for a workout template.
+
+### Medium Priority
+- [ ] **ProgressView:** Line chart of weekly workout frequency with a monthly summary card.
+- [ ] **ProfileView:** Avatar, display name, lifetime stats (total workouts, streak, PRs).
+
+## 6. Creative Freedom Guidelines
+*When the backlog is empty, follow these guidelines to innovate.*
+
+1. **Stay On-Brand:** New views must fit the "Energetic + Clean + Data-forward" vibe.
+2. **Enhance the Core:** Support the workout logging and progress tracking journey.
+3. **Naming Convention:** PascalCase, always suffixed with `View`.
+
+### Ideas to Explore
+*Pick one, build it, then REMOVE it from this list.*
+
+- [ ] `ActiveWorkoutView` - Live workout session with timer and set logging
+- [ ] `ExerciseLibraryView` - Searchable catalog of exercises with instructions
+- [ ] `AchievementsView` - Gamified milestone badges and streaks
+- [ ] `SettingsView` - Units, notifications, and account preferences
+
+## 7. Rules of Engagement
+1. Do not recreate views in Section 4.
+2. Always update `next-prompt.md` before completing.
+3. Consume ideas from Section 6 when you use them.
+4. Keep the loop moving.

--- a/skills/swiftui-loop/examples/next-prompt.md
+++ b/skills/swiftui-loop/examples/next-prompt.md
@@ -1,0 +1,25 @@
+---
+view: WorkoutsView
+---
+A browsable list of workout templates for a fitness tracking app, grouped by muscle group with bold category headers and card-style rows.
+
+**DESIGN SYSTEM (REQUIRED):**
+- Platform: iOS, SwiftUI
+- Color Scheme: Dark adaptive
+- Primary Color: Vibrant electric blue (#007AFF)
+- Background: System background (near-black #1C1C1E in dark mode)
+- Secondary Background: Elevated surface (#2C2C2E in dark mode)
+- Accent: Electric blue (#007AFF) for highlights and CTAs
+- Font Style: SF Pro Rounded, bold headlines
+- Corner Radius: 16pt (cards), 10pt (buttons)
+- Spacing: 20pt standard padding, 12pt between elements
+- SF Symbols style: filled
+- Navigation: NavigationStack with large title
+
+**Screen Structure:**
+1. Navigation bar with large title "Workouts" and a filter button (line.3.horizontal.decrease.circle)
+2. Horizontal scroll of category chips: All, Chest, Back, Legs, Arms, Core
+3. Section header "Chest" with workout count
+4. Card rows: workout name, exercise count, estimated duration, difficulty badge
+5. Repeat sections for each muscle group
+6. Floating "Create Workout" button at bottom right (plus.circle.fill)

--- a/skills/swiftui-loop/resources/app-template.md
+++ b/skills/swiftui-loop/resources/app-template.md
@@ -1,0 +1,116 @@
+# App Template
+
+Use these templates when setting up a new project for the SwiftUI build loop.
+
+## APP.md Template
+
+```markdown
+# App Vision & Constitution
+
+> **AGENT INSTRUCTION:** Read this file before every iteration. It serves as the project's "Long-Term Memory."
+
+## 1. Core Identity
+* **App Name:** [Your app name]
+* **Bundle ID:** [com.yourcompany.appname]
+* **Stitch Project ID:** [Your Stitch project ID]
+* **Mission:** [What the app does]
+* **Target Audience:** [Who uses this app]
+* **Voice:** [Tone and personality descriptors]
+* **Platform:** iOS [version]+ / iPadOS [version]+
+
+## 2. Visual Language
+*Reference these descriptors when prompting Stitch.*
+
+* **The "Vibe" (Adjectives):**
+    * *Primary:* [Main aesthetic keyword]
+    * *Secondary:* [Supporting aesthetic]
+    * *Tertiary:* [Additional flavor]
+
+## 3. Architecture & Navigation
+* **Root Navigation:** TabView with [N] tabs / NavigationStack
+* **Tab Structure:**
+    * Tab 1: [Name] → [RootView name]
+    * Tab 2: [Name] → [RootView name]
+* **Sources Directory:** `Sources/Views/`
+* **Asset Flow:** Stitch generates to `queue/` → Validate → Move to `Sources/Views/`
+
+## 4. View Inventory (Current State)
+*Update this when a new view is successfully integrated.*
+
+* [x] `ContentView` - Root tab/navigation container
+* [ ] `HomeView` - [Description]
+
+## 5. The Roadmap (Backlog)
+*Pick the next task from here if available.*
+
+### High Priority
+- [ ] [View name + description]
+- [ ] [View name + description]
+
+### Medium Priority
+- [ ] [View name + description]
+
+## 6. Creative Freedom Guidelines
+*When the backlog is empty, follow these guidelines to innovate.*
+
+1. **Stay On-Brand:** New views must fit the established vibe
+2. **Enhance the Core:** Support the app's primary user journey
+3. **Naming Convention:** PascalCase, always suffixed with `View`
+
+### Ideas to Explore
+*Pick one, build it, then REMOVE it from this list.*
+
+- [ ] `StatsView` - [Description]
+- [ ] `SettingsView` - [Description]
+
+## 7. Rules of Engagement
+1. Do not recreate views in Section 4
+2. Always update `next-prompt.md` before completing
+3. Consume ideas from Section 6 when you use them
+4. Keep the loop moving
+```
+
+---
+
+## DESIGN.md Template (SwiftUI Extended)
+
+Generate the base using the `design-md` skill from an existing Stitch screen, then **add Section 6** with SwiftUI-specific tokens:
+
+```markdown
+# Design System: [App Name]
+**Project ID:** [Stitch Project ID]
+
+## 1. Visual Theme & Atmosphere
+[Describe mood, density, aesthetic philosophy]
+
+## 2. Color Palette & Roles
+- **[Descriptive Name]** (#hexcode) – [Functional role]
+- **[Descriptive Name]** (#hexcode) – [Functional role]
+
+## 3. Typography Rules
+[Font family, weights, sizes, spacing]
+
+## 4. Component Stylings
+* **Buttons:** [Shape, color, behavior]
+* **Cards:** [Corners, background, shadows]
+* **Inputs:** [Stroke, background, focus states]
+
+## 5. Layout Principles
+[Whitespace strategy, margins, grid alignment]
+
+## 6. Design System Notes for Stitch Generation
+**Copy this block into every baton prompt:**
+
+**DESIGN SYSTEM (REQUIRED):**
+- Platform: iOS, SwiftUI
+- Color Scheme: [Dark / Light / Adaptive]
+- Primary Color: [Description] (#hex)
+- Background: [Description] (#hex or system name)
+- Secondary Background: [Description] (#hex or system name)
+- Accent: [Description] (#hex)
+- Font Style: [SF Pro / SF Pro Rounded / custom]
+- Corner Radius: [Npt (cards), Npt (buttons)]
+- Spacing: [Npt standard padding, Npt between elements]
+- SF Symbols style: [filled / outlined / monochrome]
+- Navigation: [TabView with N tabs / NavigationStack / NavigationSplitView]
+```

--- a/skills/swiftui-loop/resources/baton-schema.md
+++ b/skills/swiftui-loop/resources/baton-schema.md
@@ -1,0 +1,75 @@
+# Baton File Schema
+
+The baton file (`next-prompt.md`) is the communication mechanism between loop iterations. It tells the next agent which SwiftUI view to build.
+
+## Format
+
+```yaml
+---
+view: <SwiftViewName>
+---
+<prompt-content>
+```
+
+## Fields
+
+### Frontmatter (YAML)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `view` | string | Yes | SwiftUI view type name (PascalCase, no spaces, no `.swift` extension) |
+
+The `view` value becomes both:
+- The Stitch screen name for reference
+- The output filename: `{view}.swift`
+
+### Body (Markdown)
+
+The body contains the full Stitch prompt, which must include:
+
+1. **One-line description** with vibe/atmosphere keywords
+2. **Design System block** (required) — copied from `DESIGN.md` Section 6
+3. **Screen Structure** — numbered list of UI sections/components
+
+## Example
+
+```markdown
+---
+view: WorkoutDetailView
+---
+A focused workout detail screen with bold typography and energetic accents.
+
+**DESIGN SYSTEM (REQUIRED):**
+- Platform: iOS, SwiftUI
+- Color Scheme: Dark adaptive
+- Primary Color: Vibrant electric blue (#007AFF)
+- Background: System background (near-black in dark mode)
+- Font Style: SF Pro Rounded, bold headlines
+- Corner Radius: 16pt (cards), 10pt (buttons)
+- Spacing: 20pt standard padding, 12pt between elements
+- SF Symbols style: filled
+- Navigation: NavigationStack with large title
+
+**Screen Structure:**
+1. Large title "Chest Day" with workout category badge
+2. Stats row: duration, sets, total volume
+3. Exercise list with set/rep details and completion checkboxes
+4. Floating "Start Workout" CTA button at bottom
+```
+
+## Naming Rules
+
+- Must be valid Swift type name: PascalCase, alphanumeric only
+- Must end in `View` by convention (e.g. `ProfileView`, `SettingsView`)
+- Must NOT already exist in `APP.md` Section 4 (View Inventory)
+
+## Validation Checklist
+
+Before completing an iteration, validate your baton:
+
+- [ ] `view` frontmatter field exists and is a valid PascalCase Swift type name
+- [ ] `view` name ends in `View`
+- [ ] Prompt includes the design system block from `DESIGN.md`
+- [ ] Prompt describes a view NOT already in `APP.md` view inventory
+- [ ] Prompt includes specific screen structure details
+- [ ] `deviceType` is `MOBILE` (or explicitly overridden for iPad: `TABLET`)


### PR DESCRIPTION
## Summary
- Add `claude-code` and `github-cli` devcontainer features for easier onboarding
- Change volume names from `devcontainerId` to `homedev` for persistence across container rebuilds
- Add `/home/node/.config/gh` directory creation with proper permissions in Dockerfile
- Add commented bind mount alternatives for sharing local config
- Make `.devcontainer` mount writable (remove `readonly`)
- Remove commented gitlens extension entry

## Test plan
- [ ] Rebuild devcontainer and verify claude-code and gh CLI are available
- [ ] Verify volumes persist across container rebuilds with `homedev` naming
- [ ] Verify `/home/node/.config/gh` has correct ownership

🤖 Generated with [Claude Code](https://claude.com/claude-code)