### PR TITLE
Fix docs: correct security vulnerability reporting link

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,6 +9,6 @@
 
 ## Reporting a Vulnerability
 
-To report a security vulnerability, please use the [GitHub Security Advisory "Report a Vulnerability" tab](https://github.com/google-labs-code/jules-sdk/security/advisories/new).
+To report a security vulnerability, please use the [GitHub Security Advisory "Report a Vulnerability" tab](https://github.com/google-labs-code/stitch-skills/security/advisories/new).
 
 > **Note:** This is not an officially supported Google product. This project is not eligible for the [Google Open Source Software Vulnerability Rewards Program](https://bughunters.google.com/open-source-security).


### PR DESCRIPTION
Fixes the security vulnerability reporting link in SECURITY.md which was pointing to jules-sdk repository instead of stitch-skills repository.