### PR TITLE
Add React Native skill

### DIFF
--- a/skills/react-native/README.md
+++ b/skills/react-native/README.md
@@ -1,0 +1,36 @@
+# Stitch to React Native Components Skill
+
+## Install
+
+```bash
+npx skills add google-labs-code/stitch-skills --skill react-native --global
+```
+
+## Example Prompt
+
+```text
+Convert my Login screen in my Stitch Project to React Native components.
+```
+
+## Skill Structure
+
+This skill follows the **Agent Skills** open standard. Each skill is self-contained with its own logic, validation scripts, and design tokens.
+
+```text
+skills/react-native/
+├── SKILL.md           — Core instructions & workflow
+├── package.json       — Validator dependencies
+├── scripts/           — Networking & AST validation
+├── resources/         — Architecture checklist & component templates
+└── examples/          — Gold-standard code samples
+```
+
+## How it Works
+
+When activated, the agent follows a design-to-native pipeline:
+
+1. **Retrieval**: Uses a system-level `curl` script to download Stitch HTML and screenshots from Google Cloud Storage.
+2. **Mapping**: Translates HTML elements to React Native primitives (`View`, `Text`, `Pressable`, `Image`, etc.) and converts CSS/Tailwind to `StyleSheet.create()` calls.
+3. **Generation**: Scaffolds components using Atomic Design (atoms, molecules, organisms).
+4. **Validation**: Runs an automated AST check to catch missing Props interfaces or hardcoded style values.
+5. **Audit**: Performs a final self-correction check against the architecture checklist.

--- a/skills/react-native/SKILL.md
+++ b/skills/react-native/SKILL.md
@@ -39,7 +39,7 @@ Map HTML elements to React Native components using these rules:
 | `<input>` | `TextInput` | Map `placeholder`, `value`, `onChangeText`. |
 | `<scroll container>` | `ScrollView` | For short lists only. Use `FlatList` for long or dynamic lists. |
 | `<ul>`/`<ol>` with many items | `FlatList` | Requires `data`, `renderItem`, `keyExtractor`. |
-| `<section>` with tabs | `SectionList` | For grouped data with headers. |
+| `<section>` with grouped data | `SectionList` | For grouped data with headers. Use tab navigator for tab-based layouts. |
 | `<select>` | Third-party picker or custom modal | React Native has no built-in select. |
 | `<svg>` | `react-native-svg` | Convert SVG markup to `Svg`, `Path`, `Circle`, etc. |
 | Root wrapper | `SafeAreaView` | Wrap top-level screens to avoid notch/status bar overlap. |
@@ -106,7 +106,7 @@ const styles = StyleSheet.create({
 * **Atomic Design**: Organize components as atoms (buttons, labels, icons), molecules (input groups, cards), and organisms (headers, lists, forms). Place them in `src/components/atoms/`, `src/components/molecules/`, `src/components/organisms/`.
 * **Logic isolation**: Move event handlers, API calls, and business logic into custom hooks in `src/hooks/`. Components should only handle rendering.
 * **Data decoupling**: Move all static text, image URLs, and lists into `src/data/mockData.ts`. Components receive data through props.
-* **Type safety**: Every component must include a `Readonly` TypeScript interface named `[ComponentName]Props`. Export the interface.
+* **Type safety**: Every component must export a TypeScript interface named `[ComponentName]Props` with `readonly` property modifiers.
 * **No hardcoded styles**: Extract colors, spacing, and font sizes into `src/theme.ts`. Reference them in `StyleSheet.create()`.
 * **Navigation**: Use React Navigation for screen transitions. Define screen types with `NativeStackScreenProps` or `BottomTabScreenProps`.
 * **Accessibility**: Every interactive element must have `accessibilityLabel` and `accessibilityRole`. Images need `accessibilityLabel`. Use `accessibilityState` for toggles and checkboxes.

--- a/skills/react-native/SKILL.md
+++ b/skills/react-native/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: react-native
+name: stitch::react-native
 description: Convert Stitch HTML designs to React Native components with StyleSheet
 allowed-tools:
   - "stitch*:*"

--- a/skills/react-native/SKILL.md
+++ b/skills/react-native/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: react-native
+description: Convert Stitch HTML designs to React Native components with StyleSheet
+allowed-tools:
+  - "stitch*:*"
+  - "Bash"
+  - "Read"
+  - "Write"
+  - "web_fetch"
+---
+
+# Stitch to React Native Components
+
+You are a mobile engineer focused on transforming Stitch web designs into clean, production-ready React Native code. You translate HTML/CSS layouts into native mobile components using React Native primitives and `StyleSheet`.
+
+## Retrieval and networking
+1. **Namespace discovery**: Run `list_tools` to find the Stitch MCP prefix. Use this prefix (e.g., `stitch:`) for all subsequent calls.
+2. **Metadata fetch**: Call `[prefix]:get_screen` to retrieve the design JSON.
+3. **Check for existing designs**: Before downloading, check if `.stitch/designs/{page}.html` and `.stitch/designs/{page}.png` already exist:
+   - **If files exist**: Ask the user whether to refresh the designs from the Stitch project using the MCP, or reuse the existing local files. Only re-download if the user confirms.
+   - **If files do not exist**: Proceed to step 4.
+4. **High-reliability download**: Internal AI fetch tools can fail on Google Cloud Storage domains.
+   - **HTML**: `bash scripts/fetch-stitch.sh "[htmlCode.downloadUrl]" ".stitch/designs/{page}.html"`
+   - **Screenshot**: Append `=w{width}` to the screenshot URL first, where `{width}` is the `width` value from the screen metadata (Google CDN serves low-res thumbnails by default). Then run: `bash scripts/fetch-stitch.sh "[screenshot.downloadUrl]=w{width}" ".stitch/designs/{page}.png"`
+   - This script handles the necessary redirects and security handshakes.
+5. **Visual audit**: Review the downloaded screenshot (`.stitch/designs/{page}.png`) to confirm design intent and layout details.
+
+## HTML to React Native mapping
+
+### Element mapping
+Map HTML elements to React Native components using these rules:
+
+| HTML | React Native | Notes |
+|------|-------------|-------|
+| `<div>` | `View` | Default container |
+| `<span>`, `<p>`, `<h1>`-`<h6>` | `Text` | All text must be wrapped in `Text`. Nest `Text` for inline styling. |
+| `<img>` | `Image` | Use `source={{ uri }}` for remote images, `require()` for local assets. |
+| `<button>`, `<a>` | `Pressable` | Prefer `Pressable` over `TouchableOpacity`. Use `onPress` instead of `onClick`. |
+| `<input>` | `TextInput` | Map `placeholder`, `value`, `onChangeText`. |
+| `<scroll container>` | `ScrollView` | For short lists only. Use `FlatList` for long or dynamic lists. |
+| `<ul>`/`<ol>` with many items | `FlatList` | Requires `data`, `renderItem`, `keyExtractor`. |
+| `<section>` with tabs | `SectionList` | For grouped data with headers. |
+| `<select>` | Third-party picker or custom modal | React Native has no built-in select. |
+| `<svg>` | `react-native-svg` | Convert SVG markup to `Svg`, `Path`, `Circle`, etc. |
+| Root wrapper | `SafeAreaView` | Wrap top-level screens to avoid notch/status bar overlap. |
+
+### Style mapping
+CSS and Tailwind classes do not work in React Native. Convert all styles to `StyleSheet.create()`:
+
+**Layout**: Flexbox is the default layout system. `flexDirection` defaults to `'column'` (not `'row'` like web CSS).
+- `display: flex` is implicit on every `View`.
+- `justify-content` maps to `justifyContent`.
+- `align-items` maps to `alignItems`.
+- `gap` maps to `gap` (React Native 0.71+). For older versions, use `marginBottom` on children.
+
+**Dimensions**: Use numbers (not strings). `width: 100` means 100 density-independent pixels.
+- Percentage strings are supported: `width: '100%'`.
+- For responsive sizing, use `useWindowDimensions()` from `react-native`.
+- There is no `vw`/`vh`. Calculate from `Dimensions.get('window')`.
+
+**Typography**: All text styles must be on `Text` components, never on `View`.
+- `font-size` maps to `fontSize` (number, not string).
+- `font-weight` maps to `fontWeight` (string: `'400'`, `'700'`, `'bold'`).
+- `line-height` maps to `lineHeight` (number).
+- `letter-spacing` maps to `letterSpacing`.
+- `text-transform` maps to `textTransform`.
+- `color` applies to `Text` only.
+
+**Borders and shadows**:
+- `border-radius` maps to `borderRadius`.
+- `box-shadow` does not exist. Use `elevation` (Android) and `shadowColor`/`shadowOffset`/`shadowOpacity`/`shadowRadius` (iOS).
+- Use `Platform.select()` to apply platform-specific shadow styles.
+
+**Unsupported CSS properties** (handle manually or skip):
+- `hover`, `transition`, `animation` (use `react-native-reanimated` for animations).
+- `position: fixed` (use `position: 'absolute'` with manual offset).
+- `overflow: auto` (use `ScrollView`).
+- `z-index` works but only between sibling views.
+- `opacity` works. `visibility: hidden` does not exist; use conditional rendering or `opacity: 0`.
+
+**Color extraction**: Extract the Tailwind config from the HTML `<head>`. Map color tokens to a `theme.ts` constants file instead of hardcoding hex values in StyleSheet.
+
+### Platform-specific code
+When the design requires different behavior on iOS and Android:
+
+```typescript
+import { Platform } from 'react-native';
+
+const styles = StyleSheet.create({
+  shadow: Platform.select({
+    ios: {
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.1,
+      shadowRadius: 4,
+    },
+    android: {
+      elevation: 4,
+    },
+  }),
+});
+```
+
+## Architectural rules
+
+* **Atomic Design**: Organize components as atoms (buttons, labels, icons), molecules (input groups, cards), and organisms (headers, lists, forms). Place them in `src/components/atoms/`, `src/components/molecules/`, `src/components/organisms/`.
+* **Logic isolation**: Move event handlers, API calls, and business logic into custom hooks in `src/hooks/`. Components should only handle rendering.
+* **Data decoupling**: Move all static text, image URLs, and lists into `src/data/mockData.ts`. Components receive data through props.
+* **Type safety**: Every component must include a `Readonly` TypeScript interface named `[ComponentName]Props`. Export the interface.
+* **No hardcoded styles**: Extract colors, spacing, and font sizes into `src/theme.ts`. Reference them in `StyleSheet.create()`.
+* **Navigation**: Use React Navigation for screen transitions. Define screen types with `NativeStackScreenProps` or `BottomTabScreenProps`.
+* **Accessibility**: Every interactive element must have `accessibilityLabel` and `accessibilityRole`. Images need `accessibilityLabel`. Use `accessibilityState` for toggles and checkboxes.
+* **Safe areas**: Wrap top-level screen components with `SafeAreaView` from `react-native-safe-area-context` (not the one from `react-native`).
+* **Project specific**: Focus on the target project's needs and constraints. Leave Google license headers out of the generated React Native components.
+
+## Execution steps
+
+1. **Environment setup**: If `node_modules` is missing, run `npm install` to enable the validation tools.
+2. **Theme layer**: Create `src/theme.ts` from the extracted Tailwind config. Define colors, spacing, typography, and shadow presets.
+3. **Data layer**: Create `src/data/mockData.ts` based on the design content. Extract all text, image URIs, and list data.
+4. **Component drafting**: Use `resources/component-template.tsx` as a base. Find and replace all instances of `StitchComponent` with the actual component name. Map HTML elements to React Native primitives following the mapping table above.
+5. **Navigation wiring**: If the design has multiple screens, set up a `NavigationContainer` with a stack or tab navigator in `App.tsx`.
+6. **Quality check**:
+   * Run `npm run validate <file_path>` for each component.
+   * Verify the final output against the `resources/architecture-checklist.md`.
+   * Start Metro with `npx react-native start` or `npx expo start` to verify the live result on a simulator/device.
+
+## Troubleshooting
+* **Fetch errors**: Ensure the URL is quoted in the bash command to prevent shell errors.
+* **Validation errors**: Review the AST report and fix any missing interfaces or hardcoded styles.
+* **Text outside Text component**: React Native crashes if raw strings appear outside `<Text>`. Verify all text nodes are wrapped.
+* **Image sizing**: Unlike web `<img>`, React Native `Image` has no intrinsic size. Always specify `width` and `height` in styles or use `aspectRatio`.
+* **FlatList vs ScrollView**: If you see a "VirtualizedList inside ScrollView" warning, replace the outer `ScrollView` with a plain `View` or use `FlatList` `ListHeaderComponent`/`ListFooterComponent`.

--- a/skills/react-native/examples/gold-standard-card.tsx
+++ b/skills/react-native/examples/gold-standard-card.tsx
@@ -1,0 +1,176 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { View, Text, Image, Pressable, StyleSheet, Platform } from 'react-native';
+
+/**
+ * Gold Standard: ActivityCard
+ * This file is the definitive reference for the agent.
+ */
+interface ActivityCardProps {
+  readonly id: string;
+  readonly username: string;
+  readonly action: 'MERGED' | 'COMMIT';
+  readonly timestamp: string;
+  readonly avatarUrl: string;
+  readonly repoName: string;
+  readonly onPress?: () => void;
+}
+
+export const ActivityCard: React.FC<ActivityCardProps> = ({
+  username,
+  action,
+  timestamp,
+  avatarUrl,
+  repoName,
+  onPress,
+}) => {
+  const isMerged = action === 'MERGED';
+
+  return (
+    <Pressable
+      style={({ pressed }) => [styles.container, pressed && styles.pressed]}
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={`${username} ${action.toLowerCase()} in ${repoName}`}
+    >
+      <View style={styles.leftContent}>
+        <Image
+          source={{ uri: avatarUrl }}
+          style={styles.avatar}
+          accessibilityLabel={`Avatar for ${username}`}
+        />
+
+        <View style={styles.textContent}>
+          <Text style={styles.username} numberOfLines={1}>
+            {username}
+          </Text>
+
+          <View
+            style={[
+              styles.badge,
+              isMerged ? styles.badgeMerged : styles.badgeCommit,
+            ]}
+          >
+            <Text
+              style={[
+                styles.badgeText,
+                isMerged ? styles.badgeTextMerged : styles.badgeTextCommit,
+              ]}
+            >
+              {action}
+            </Text>
+          </View>
+
+          <Text style={styles.separator}>in</Text>
+
+          <Text style={styles.repoName} numberOfLines={1}>
+            {repoName}
+          </Text>
+        </View>
+      </View>
+
+      <Text style={styles.timestamp}>{timestamp}</Text>
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 16,
+    borderRadius: 8,
+    padding: 16,
+    minHeight: 56,
+    ...Platform.select({
+      ios: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 1 },
+        shadowOpacity: 0.1,
+        shadowRadius: 2,
+      },
+      android: {
+        elevation: 2,
+      },
+    }),
+  },
+  pressed: {
+    opacity: 0.7,
+  },
+  leftContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 16,
+    flex: 1,
+    overflow: 'hidden',
+  },
+  avatar: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+  },
+  textContent: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    columnGap: 8,
+    rowGap: 4,
+    flex: 1,
+  },
+  username: {
+    fontWeight: '600',
+    fontSize: 14,
+  },
+  badge: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 12,
+  },
+  badgeMerged: {
+    backgroundColor: 'rgba(138, 43, 226, 0.3)',
+  },
+  badgeCommit: {
+    backgroundColor: 'rgba(25, 230, 111, 0.3)',
+  },
+  badgeText: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  badgeTextMerged: {
+    color: '#D0A9F5',
+  },
+  badgeTextCommit: {
+    color: '#19E66F',
+  },
+  separator: {
+    fontSize: 14,
+    opacity: 0.6,
+  },
+  repoName: {
+    fontSize: 14,
+  },
+  timestamp: {
+    fontSize: 14,
+    fontWeight: '400',
+    opacity: 0.5,
+    flexShrink: 0,
+  },
+});
+
+export default ActivityCard;

--- a/skills/react-native/examples/gold-standard-card.tsx
+++ b/skills/react-native/examples/gold-standard-card.tsx
@@ -16,12 +16,13 @@
 
 import React from 'react';
 import { View, Text, Image, Pressable, StyleSheet, Platform } from 'react-native';
+import { colors, shadows } from '../src/theme';
 
 /**
  * Gold Standard: ActivityCard
  * This file is the definitive reference for the agent.
  */
-interface ActivityCardProps {
+export interface ActivityCardProps {
   readonly id: string;
   readonly username: string;
   readonly action: 'MERGED' | 'COMMIT';
@@ -98,17 +99,7 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     padding: 16,
     minHeight: 56,
-    ...Platform.select({
-      ios: {
-        shadowColor: '#000',
-        shadowOffset: { width: 0, height: 1 },
-        shadowOpacity: 0.1,
-        shadowRadius: 2,
-      },
-      android: {
-        elevation: 2,
-      },
-    }),
+    ...shadows.card,
   },
   pressed: {
     opacity: 0.7,
@@ -143,20 +134,20 @@ const styles = StyleSheet.create({
     borderRadius: 12,
   },
   badgeMerged: {
-    backgroundColor: 'rgba(138, 43, 226, 0.3)',
+    backgroundColor: colors.badgeMergedBg,
   },
   badgeCommit: {
-    backgroundColor: 'rgba(25, 230, 111, 0.3)',
+    backgroundColor: colors.badgeCommitBg,
   },
   badgeText: {
     fontSize: 12,
     fontWeight: '600',
   },
   badgeTextMerged: {
-    color: '#D0A9F5',
+    color: colors.badgeMergedText,
   },
   badgeTextCommit: {
-    color: '#19E66F',
+    color: colors.badgeCommitText,
   },
   separator: {
     fontSize: 14,

--- a/skills/react-native/package.json
+++ b/skills/react-native/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "react-native-components",
+  "version": "1.0.0",
+  "description": "Design-to-code prompt to React Native components for Stitch MCP",
+  "type": "module",
+  "scripts": {
+    "validate": "node scripts/validate.js",
+    "fetch": "bash scripts/fetch-stitch.sh"
+  },
+  "dependencies": {
+    "@swc/core": "^1.3.100"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/skills/react-native/resources/architecture-checklist.md
+++ b/skills/react-native/resources/architecture-checklist.md
@@ -1,0 +1,37 @@
+# Architecture Quality Gate
+
+### Structural integrity
+- [ ] Components organized by Atomic Design: atoms, molecules, organisms in `src/components/`.
+- [ ] Logic extracted to custom hooks in `src/hooks/`.
+- [ ] No monolithic files. Each component in its own file.
+- [ ] All static text, image URIs, and list data moved to `src/data/mockData.ts`.
+
+### Type safety and syntax
+- [ ] Every component has a `Readonly<T>` Props interface exported from the file.
+- [ ] File is syntactically valid TypeScript (no parse errors).
+- [ ] Placeholders from template (e.g., `StitchComponent`) have been replaced with actual names.
+- [ ] Navigation screen params are typed with `NativeStackScreenProps` or equivalent.
+
+### React Native primitives
+- [ ] No HTML elements (`div`, `span`, `p`, `img`, `button`). Only React Native components.
+- [ ] All text wrapped in `Text` components. No raw strings inside `View`.
+- [ ] `Pressable` used for interactive elements (not `TouchableOpacity` or `TouchableHighlight`).
+- [ ] `FlatList` used for dynamic/long lists (not `ScrollView` with `.map()`).
+- [ ] `Image` components have explicit `width` and `height` or `aspectRatio`.
+
+### Styling
+- [ ] All styles defined via `StyleSheet.create()` at the bottom of the file.
+- [ ] No inline style objects (use `StyleSheet` references).
+- [ ] No hardcoded hex values. Colors referenced from `src/theme.ts`.
+- [ ] Shadows use `Platform.select()` for iOS/Android differences.
+- [ ] `flexDirection` explicitly set where row layout is needed (default is `column`).
+
+### Accessibility
+- [ ] Interactive elements have `accessibilityLabel` and `accessibilityRole`.
+- [ ] Images have descriptive `accessibilityLabel`.
+- [ ] Toggle/checkbox elements use `accessibilityState`.
+
+### Platform handling
+- [ ] Top-level screens wrapped with `SafeAreaView` from `react-native-safe-area-context`.
+- [ ] Platform-specific code uses `Platform.select()` or `Platform.OS` checks.
+- [ ] Responsive dimensions use `useWindowDimensions()` (not hardcoded pixel values for screen-relative sizing).

--- a/skills/react-native/resources/architecture-checklist.md
+++ b/skills/react-native/resources/architecture-checklist.md
@@ -7,7 +7,7 @@
 - [ ] All static text, image URIs, and list data moved to `src/data/mockData.ts`.
 
 ### Type safety and syntax
-- [ ] Every component has a `Readonly<T>` Props interface exported from the file.
+- [ ] Every component exports a `[ComponentName]Props` interface with `readonly` property modifiers.
 - [ ] File is syntactically valid TypeScript (no parse errors).
 - [ ] Placeholders from template (e.g., `StitchComponent`) have been replaced with actual names.
 - [ ] Navigation screen params are typed with `NativeStackScreenProps` or equivalent.

--- a/skills/react-native/resources/component-template.tsx
+++ b/skills/react-native/resources/component-template.tsx
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+interface StitchComponentProps {
+  readonly children?: React.ReactNode;
+  readonly testID?: string;
+}
+
+export const StitchComponent: React.FC<StitchComponentProps> = ({
+  children,
+  testID,
+}) => {
+  return (
+    <View style={styles.container} testID={testID} accessibilityRole="none">
+      {children}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});
+
+export default StitchComponent;

--- a/skills/react-native/resources/component-template.tsx
+++ b/skills/react-native/resources/component-template.tsx
@@ -1,23 +1,7 @@
-/**
- * Copyright 2026 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 
-interface StitchComponentProps {
+export interface StitchComponentProps {
   readonly children?: React.ReactNode;
   readonly testID?: string;
 }
@@ -34,9 +18,7 @@ export const StitchComponent: React.FC<StitchComponentProps> = ({
 };
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
+  container: {},
 });
 
 export default StitchComponent;

--- a/skills/react-native/scripts/fetch-stitch.sh
+++ b/skills/react-native/scripts/fetch-stitch.sh
@@ -19,6 +19,7 @@ if [ -z "$URL" ] || [ -z "$OUTPUT" ]; then
   echo "Usage: $0 <url> <output_path>"
   exit 1
 fi
+mkdir -p "$(dirname "$OUTPUT")"
 echo "Initiating high-reliability fetch for Stitch HTML..."
 curl -L -f -sS --connect-timeout 10 --compressed "$URL" -o "$OUTPUT"
 if [ $? -eq 0 ]; then

--- a/skills/react-native/scripts/fetch-stitch.sh
+++ b/skills/react-native/scripts/fetch-stitch.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+URL=$1
+OUTPUT=$2
+if [ -z "$URL" ] || [ -z "$OUTPUT" ]; then
+  echo "Usage: $0 <url> <output_path>"
+  exit 1
+fi
+echo "Initiating high-reliability fetch for Stitch HTML..."
+curl -L -f -sS --connect-timeout 10 --compressed "$URL" -o "$OUTPUT"
+if [ $? -eq 0 ]; then
+  echo "Successfully retrieved HTML at: $OUTPUT"
+  exit 0
+else
+  echo "Error: Failed to retrieve content. Check TLS/SNI or URL expiration."
+  exit 1
+fi

--- a/skills/react-native/scripts/validate.js
+++ b/skills/react-native/scripts/validate.js
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import swc from '@swc/core';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const HEX_COLOR_REGEX = /#[0-9A-Fa-f]{6}/;
+const HTML_ELEMENTS = ['div', 'span', 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'img', 'button', 'a', 'input', 'ul', 'ol', 'li', 'section', 'header', 'footer', 'nav', 'main'];
+
+async function validateComponent(filePath) {
+  const code = fs.readFileSync(filePath, 'utf-8');
+  const filename = path.basename(filePath);
+  try {
+    const ast = await swc.parse(code, { syntax: "typescript", tsx: true });
+    let hasInterface = false;
+    let hexIssues = [];
+    let htmlElements = [];
+
+    console.log("Scanning AST...");
+
+    const walk = (node) => {
+      if (!node) return;
+
+      if (node.type === 'TsInterfaceDeclaration' && node.id.value.endsWith('Props')) {
+        hasInterface = true;
+      }
+
+      // Check for hardcoded hex in StyleSheet values
+      if (node.type === 'StringLiteral' && HEX_COLOR_REGEX.test(node.value)) {
+        hexIssues.push(node.value);
+      }
+
+      // Check for HTML elements used as JSX tags
+      if (node.type === 'JSXOpeningElement' && node.name?.type === 'Identifier') {
+        const tagName = node.name.value;
+        if (HTML_ELEMENTS.includes(tagName)) {
+          htmlElements.push(tagName);
+        }
+      }
+
+      for (const key in node) {
+        if (node[key] && typeof node[key] === 'object') walk(node[key]);
+      }
+    };
+    walk(ast);
+
+    console.log(`--- Validation for: ${filename} ---`);
+
+    let valid = true;
+
+    if (hasInterface) {
+      console.log("PASS: Props declaration found.");
+    } else {
+      console.error("FAIL: Missing Props interface (must end in 'Props').");
+      valid = false;
+    }
+
+    if (hexIssues.length === 0) {
+      console.log("PASS: No hardcoded hex values found.");
+    } else {
+      console.error(`FAIL: Found ${hexIssues.length} hardcoded hex codes. Use theme.ts instead.`);
+      hexIssues.forEach(hex => console.error(`   - ${hex}`));
+      valid = false;
+    }
+
+    if (htmlElements.length === 0) {
+      console.log("PASS: No HTML elements found. Using React Native primitives.");
+    } else {
+      const unique = [...new Set(htmlElements)];
+      console.error(`FAIL: Found HTML elements: ${unique.join(', ')}. Replace with React Native components.`);
+      valid = false;
+    }
+
+    if (valid) {
+      console.log("\nCOMPONENT VALID.");
+      process.exit(0);
+    } else {
+      console.error("\nVALIDATION FAILED.");
+      process.exit(1);
+    }
+  } catch (err) {
+    console.error("PARSE ERROR:", err.message);
+    process.exit(1);
+  }
+}
+
+validateComponent(process.argv[2]);

--- a/skills/react-native/scripts/validate.js
+++ b/skills/react-native/scripts/validate.js
@@ -18,7 +18,8 @@ import swc from '@swc/core';
 import fs from 'node:fs';
 import path from 'node:path';
 
-const HEX_COLOR_REGEX = /#[0-9A-Fa-f]{6}/;
+const HEX_COLOR_REGEX = /#[0-9A-Fa-f]{3,8}\b/;
+const RGBA_COLOR_REGEX = /^rgba?\(\s*\d/;
 const HTML_ELEMENTS = ['div', 'span', 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'img', 'button', 'a', 'input', 'ul', 'ol', 'li', 'section', 'header', 'footer', 'nav', 'main'];
 
 async function validateComponent(filePath) {
@@ -27,21 +28,30 @@ async function validateComponent(filePath) {
   try {
     const ast = await swc.parse(code, { syntax: "typescript", tsx: true });
     let hasInterface = false;
-    let hexIssues = [];
+    let hasExportedInterface = false;
+    let colorIssues = [];
     let htmlElements = [];
 
     console.log("Scanning AST...");
 
-    const walk = (node) => {
+    const walk = (node, parent) => {
       if (!node) return;
 
       if (node.type === 'TsInterfaceDeclaration' && node.id.value.endsWith('Props')) {
         hasInterface = true;
+        if (parent?.type === 'ExportDeclaration') {
+          hasExportedInterface = true;
+        }
       }
 
-      // Check for hardcoded hex in StyleSheet values
+      // Check for hardcoded hex values in strings
       if (node.type === 'StringLiteral' && HEX_COLOR_REGEX.test(node.value)) {
-        hexIssues.push(node.value);
+        colorIssues.push(node.value);
+      }
+
+      // Check for rgba() color strings
+      if (node.type === 'StringLiteral' && RGBA_COLOR_REGEX.test(node.value)) {
+        colorIssues.push(node.value);
       }
 
       // Check for HTML elements used as JSX tags
@@ -53,27 +63,30 @@ async function validateComponent(filePath) {
       }
 
       for (const key in node) {
-        if (node[key] && typeof node[key] === 'object') walk(node[key]);
+        if (node[key] && typeof node[key] === 'object') walk(node[key], node);
       }
     };
-    walk(ast);
+    walk(ast, null);
 
     console.log(`--- Validation for: ${filename} ---`);
 
     let valid = true;
 
-    if (hasInterface) {
-      console.log("PASS: Props declaration found.");
+    if (hasExportedInterface) {
+      console.log("PASS: Exported Props interface found.");
+    } else if (hasInterface) {
+      console.error("WARN: Props interface found but not exported. Add 'export' keyword.");
+      valid = false;
     } else {
-      console.error("FAIL: Missing Props interface (must end in 'Props').");
+      console.error("FAIL: Missing Props interface (must end in 'Props' and be exported).");
       valid = false;
     }
 
-    if (hexIssues.length === 0) {
-      console.log("PASS: No hardcoded hex values found.");
+    if (colorIssues.length === 0) {
+      console.log("PASS: No hardcoded color values found.");
     } else {
-      console.error(`FAIL: Found ${hexIssues.length} hardcoded hex codes. Use theme.ts instead.`);
-      hexIssues.forEach(hex => console.error(`   - ${hex}`));
+      console.error(`FAIL: Found ${colorIssues.length} hardcoded colors. Use theme.ts instead.`);
+      colorIssues.forEach(c => console.error(`   - ${c}`));
       valid = false;
     }
 


### PR DESCRIPTION
Adds a `react-native` skill that converts Stitch HTML designs into React Native components with `StyleSheet`.

Closes #41, relates to #19.

## What it does

- Maps HTML elements to React Native primitives (`View`, `Text`, `Pressable`, `Image`, `FlatList`, etc.)
- Converts CSS/Tailwind to `StyleSheet.create()` with theme token references
- Handles platform-specific code (`Platform.select()` for shadows, `SafeAreaView` for notch handling)
- Uses Atomic Design for component organization (atoms/molecules/organisms)
- Includes accessibility (`accessibilityLabel`, `accessibilityRole`, `accessibilityState`)
- Decouples data into `mockData.ts`, logic into custom hooks
- Provides AST validation that catches HTML elements, missing Props interfaces, and hardcoded hex values

## Skill structure

```
skills/react-native/
├── SKILL.md                              — Core instructions & workflow
├── README.md                             — Install & usage
├── package.json                          — Validator dependencies
├── scripts/fetch-stitch.sh               — Stitch asset downloader
├── scripts/validate.js                   — AST validator (Props, hex, HTML element checks)
├── resources/architecture-checklist.md   — Quality gate checklist
├── resources/component-template.tsx      — Starter template
└── examples/gold-standard-card.tsx       — Reference implementation
```

Modeled after the existing `react-components` skill, adapted for React Native's different primitives, styling system, and platform constraints.