### PR TITLE
Update Google Stitch URL in taste-design skill

### DIFF
--- a/skills/taste-design/SKILL.md
+++ b/skills/taste-design/SKILL.md
@@ -15,7 +15,7 @@ This skill generates `DESIGN.md` files optimized for Google Stitch screen genera
 The generated `DESIGN.md` serves as the **single source of truth** for prompting Stitch to generate new screens that align with a curated, high-agency design language. Stitch interprets design through **"Visual Descriptions"** supported by specific color values, typography specs, and component behaviors.
 
 ## Prerequisites
-- Access to Google Stitch via [labs.google.com/stitch](https://labs.google.com/stitch)
+- Access to Google Stitch via [stitch.withgoogle.com](https://stitch.withgoogle.com/)
 - Optionally: Stitch MCP Server for programmatic integration with Cursor, Antigravity, or Gemini CLI
 
 ## The Goal


### PR DESCRIPTION
Replace the old reference to labs.google.com/stitch with the new official domain stitch.withgoogle.com. This ensures users are directed to the correct and current location for Google Stitch.