### PR TITLE
Expand Stitch full-stack loop and content-system guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,21 +17,26 @@ npx skills add google-labs-code/stitch-skills --skill react:components --global
 ## Available Skills
 
 ### stitch-design
-Unified entry point for Stitch design work. Handles prompt enhancement (UI/UX keywords, atmosphere), design system synthesis (.stitch/DESIGN.md), and high-fidelity screen generation/editing via Stitch MCP.
+Unified entry point for Stitch design work. Handles prompt enhancement (UI/UX keywords, atmosphere), design system synthesis (`.stitch/DESIGN.md`), and high-fidelity screen generation and editing via Stitch MCP.
 
 ```bash
 npx skills add google-labs-code/stitch-skills --skill stitch-design --global
 ```
 
 ### stitch-loop
-Generates a complete multi-page website from a single prompt using Stitch, with automated file organization and validation.
+Guides an agent through a full Stitch design-to-code loop: prompt and baton intake, Stitch generation, repo integration, browser QA, review, fix, retest, and next-iteration handoff.
 
 ```bash
 npx skills add google-labs-code/stitch-skills --skill stitch-loop --global
 ```
 
+Key resources inside this skill:
+- `skills/stitch-loop/resources/fullstack-playbook.md`
+- `skills/stitch-loop/resources/stitch-mcp-setup.md`
+- `skills/stitch-loop/resources/openclaw-browser-qa.md`
+
 ### design-md
-Analyzes Stitch projects and generates comprehensive DESIGN.md files documenting design systems in natural, semantic language optimized for Stitch screen generation.
+Analyzes Stitch projects and generates comprehensive `DESIGN.md` files documenting design systems in natural, semantic language optimized for Stitch screen generation.
 
 ```bash
 npx skills add google-labs-code/stitch-skills --skill design-md --global
@@ -65,24 +70,36 @@ Expert guidance for integrating and building applications with shadcn/ui compone
 npx skills add google-labs-code/stitch-skills --skill shadcn-ui --global
 ```
 
+## Recommended Design-to-Code Flow
+
+A practical full-stack flow with this repo looks like this:
+
+1. Use `stitch-design` to refine prompts and stabilize the design system
+2. Use `design-md` if `.stitch/DESIGN.md` does not exist yet
+3. Use `stitch-loop` to run the delivery loop from design through integration and QA
+4. Use `react:components` when Stitch output needs to become modular React code
+5. Run real browser QA before calling the slice done
+
 ## Repository Structure
 
-Every directory within `skills/` or at the root level follows a standardized structure to ensure the AI agent has everything it needs to perform "few-shot" learning and automated quality checks.
+Every directory within `skills/` or at the root level follows a standardized structure to ensure the AI agent has everything it needs to perform few-shot learning and automated quality checks.
 
 ```text
 skills/[category]/
-├── SKILL.md           — The "Mission Control" for the agent
-├── scripts/           — Executable enforcers (Validation & Networking)
-├── resources/         — The knowledge base (Checklists & Style Guides)
-└── examples/          — The "Gold Standard" syntactically valid references
+├── SKILL.md           - The mission control for the agent
+├── scripts/           - Executable enforcers (validation and networking)
+├── resources/         - The knowledge base (checklists and style guides)
+└── examples/          - Gold-standard references
 ```
 
 ## Adding New Skills
+
 All new skills need to follow the file structure above to implement the Agent Skills open standard.
 
 ### Great candidates for new skills
-* **Validation**: Skills that convert Stitch HTML to other UI frameworks and validate the syntax.
-* **Decoupling Data**: Skills that convert static design content into external mock data files.
-* **Generate Designs**: Skills that generate new design screens in Stitch from a given set of data.
+
+- **Validation**: Skills that convert Stitch HTML to other UI frameworks and validate the syntax
+- **Decoupling Data**: Skills that convert static design content into external mock data files
+- **Generate Designs**: Skills that generate new design screens in Stitch from a given set of data
 
 This is not an officially supported Google product. This project is not eligible for the [Google Open Source Software Vulnerability Rewards Program](https://bughunters.google.com/open-source-security).

--- a/README.md
+++ b/README.md
@@ -82,14 +82,14 @@ A practical full-stack flow with this repo looks like this:
 
 ## Repository Structure
 
-Every directory within `skills/` or at the root level follows a standardized structure to ensure the AI agent has everything it needs to perform few-shot learning and automated quality checks.
+Skills in this repository commonly follow a standardized structure so the AI agent has what it needs for few-shot learning and automated quality checks. Not every skill uses every optional subdirectory.
 
 ```text
 skills/[category]/
 ├── SKILL.md           - The mission control for the agent
-├── scripts/           - Executable enforcers (validation and networking)
-├── resources/         - The knowledge base (checklists and style guides)
-└── examples/          - Gold-standard references
+├── scripts/           - Optional executable helpers for validation and networking
+├── resources/         - Optional knowledge base files such as checklists and style guides
+└── examples/          - Optional gold-standard references
 ```
 
 ## Adding New Skills

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npx skills add google-labs-code/stitch-skills --skill react:components --global
 ## Available Skills
 
 ### stitch-design
-Unified entry point for Stitch design work. Handles prompt enhancement (UI/UX keywords, atmosphere), design system synthesis (`.stitch/DESIGN.md`), and high-fidelity screen generation and editing via Stitch MCP.
+Unified entry point for Stitch design work. Handles prompt enhancement, design system synthesis (`.stitch/DESIGN.md`), and high-fidelity generation or editing for web pages, app flows, and reusable content layouts such as social carousel posts.
 
 ```bash
 npx skills add google-labs-code/stitch-skills --skill stitch-design --global

--- a/skills/stitch-design/README.md
+++ b/skills/stitch-design/README.md
@@ -1,6 +1,6 @@
 # Stitch Design Skill
 
-Teaches agents to generate high-fidelity, consistent UI designs and maintain project-level design systems using Stitch.
+Teaches agents to generate high-fidelity, consistent designs and maintain project-level design systems using Stitch.
 
 ## Install
 
@@ -10,40 +10,41 @@ npx skills add google-labs-code/stitch-skills --skill stitch-design --global
 
 ## What It Does
 
-Enables professional-grade UI/UX design workflows through Stitch MCP:
+Enables professional-grade design workflows through Stitch MCP:
 
-1. **Prompt Enhancement**: Transforms rough intent into structured, high-fidelity prompts with professional terminology and design system context.
-2. **Design System Synthesis**: Analyzes existing Stitch projects to create and maintain a `.stitch/DESIGN.md` "source of truth".
-3. **Iterative Generation**: Selects the best generation or editing workflow (`edit_screens`, `generate_variants`) based on user intent.
-4. **Asset Management**: Synchronizes remote designs by downloading HTML and screenshots to the project's `.stitch/designs` directory.
+1. **Prompt Enhancement**: Transforms rough intent into structured, high-fidelity prompts with professional design terminology and system context.
+2. **Design System Synthesis**: Analyzes existing Stitch projects to create and maintain a `.stitch/DESIGN.md` source of truth.
+3. **Iterative Generation**: Selects the best generation or editing workflow based on user intent.
+4. **Asset Management**: Synchronizes remote designs by downloading HTML and screenshots to `.stitch/designs`.
+5. **Handoff Readiness**: Produces output that can move cleanly into `stitch-loop` or `react:components`.
+6. **Content-System Support**: Works for app pages, web flows, and reusable content layouts such as social carousel posts.
 
 ## Prerequisites
 
 - Stitch MCP Server access
-- A project `projectId` (can be discovered via `list_projects`)
+- A project `projectId` if you are continuing an existing project
 
-## Example Prompt
+## Example Prompts
 
 ```text
 Design a premium landing page for a mountain resort with a focus on serene luxury and glassmorphism.
 ```
 
-## Skill Structure
+```text
+Design a 6-slide XiaohongShu-style carousel explaining why long-term investing beats chasing hot themes.
+```
 
-```
-stitch-design/
-├── SKILL.md           — Core instructions & Prompt Pipeline
-├── README.md          — This file
-├── workflows/         — Specialized pipelines (Text-to-UI, Edit, MD)
-├── references/        — UI/UX keywords & Technical Mappings
-└── examples/          — Gold-standard references (Solace Mindfulness)
-```
+## Example Files
+
+- `examples/enhanced-prompt.md`
+- `examples/xiaohongshu-carousel-prompt.md`
+- `examples/fullstack-handoff.md`
 
 ## Works With
 
-- **`react:components` skill**: Hand-off generated designs for frontend implementation.
-- **`stitch-loop` skill**: Provides the `DESIGN.md` context for autonomous building loops.
-- **Multi-agent workflows**: Refines prompts before passing design tasks to specialized agents.
+- **`react:components`** for frontend implementation handoff
+- **`stitch-loop`** for design to code to QA iteration loops
+- **multi-agent workflows** that split design, implementation, QA, and fix passes
 
 ## Learn More
 

--- a/skills/stitch-design/README.md
+++ b/skills/stitch-design/README.md
@@ -18,6 +18,7 @@ Enables professional-grade design workflows through Stitch MCP:
 4. **Asset Management**: Synchronizes remote designs by downloading HTML and screenshots to `.stitch/designs`.
 5. **Handoff Readiness**: Produces output that can move cleanly into `stitch-loop` or `react:components`.
 6. **Content-System Support**: Works for app pages, web flows, and reusable content layouts such as social carousel posts.
+7. **Discovery-Friendly Workflow**: Encourages research, source gathering, and human collaboration before finalizing publishable content sets.
 
 ## Prerequisites
 
@@ -38,7 +39,12 @@ Design a 6-slide XiaohongShu-style carousel explaining why long-term investing b
 
 - `examples/enhanced-prompt.md`
 - `examples/xiaohongshu-carousel-prompt.md`
+- `examples/xiaohongshu-content-brief.md`
 - `examples/fullstack-handoff.md`
+
+## Key Reference
+
+- `references/content-system-playbook.md` for social-post discovery, research gathering, human approval points, and slide architecture guidance
 
 ## Works With
 

--- a/skills/stitch-design/SKILL.md
+++ b/skills/stitch-design/SKILL.md
@@ -37,6 +37,7 @@ If the user is designing a content series rather than an app page, think in term
 - brand consistency across all slides
 
 For a concrete content-series example, see [Xiaohongshu carousel example](examples/xiaohongshu-carousel-prompt.md).
+When the request is a research-driven content set or social post series, also read [Content system playbook](references/content-system-playbook.md).
 
 ## Workflows
 
@@ -56,6 +57,8 @@ Before calling any Stitch generation or editing tool, enhance the user's prompt.
 - **Project scope**: Maintain the current `projectId`. Use `list_projects` if unknown.
 - **Design system**: Check for `.stitch/DESIGN.md`. If it exists, incorporate its tokens. If not, suggest the `generate-design-md` workflow.
 - **Delivery target**: Identify whether the design is for a real product surface, a prototype, or a content asset set.
+- **Research state**: If the design depends on facts, examples, screenshots, product claims, or market context, gather the source material first. If key inputs are missing, ask targeted questions or request approved copy before designing.
+- **Human collaboration**: For publishable content assets, treat human approval as part of the workflow rather than assuming the first generated set is final.
 
 ### 2. Refine terminology
 Consult [Design Mappings](references/design-mappings.md) to replace vague terms.
@@ -96,6 +99,11 @@ If the design will later be implemented or QA'd:
 - preserve useful screen naming or slugging
 - mention whether the next step should be `stitch-loop` or `react:components`
 
+If the output is a content set rather than app UI:
+- preserve slide order and per-slide purpose
+- note any assumptions or unverified claims that still need human review
+- package a short slide-by-slide summary that another agent or reviewer can use without reopening the whole design context
+
 ---
 
 ## References
@@ -103,6 +111,7 @@ If the design will later be implemented or QA'd:
 - [Tool Schemas](references/tool-schemas.md) for how to call Stitch MCP tools
 - [Design Mappings](references/design-mappings.md) for UI or editorial language upgrades
 - [Prompting Keywords](references/prompt-keywords.md) for technical terms Stitch understands well
+- [Content system playbook](references/content-system-playbook.md) for discovery, research, human collaboration, and multi-slide social content workflows
 
 ---
 

--- a/skills/stitch-design/SKILL.md
+++ b/skills/stitch-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stitch-design
-description: Unified entry point for Stitch design work. Handles prompt enhancement (UI/UX keywords, atmosphere), design system synthesis (.stitch/DESIGN.md), and high-fidelity screen generation/editing via Stitch MCP.
+description: Unified entry point for Stitch design work. Handles prompt enhancement, design system synthesis, MCP-aware design setup, and high-fidelity screen generation or editing for web pages, app flows, and reusable content layouts such as social or carousel posts.
 allowed-tools:
   - "StitchMCP"
   - "Read"
@@ -13,72 +13,103 @@ You are an expert Design Systems Lead and Prompt Engineer specializing in the **
 
 ## Core Responsibilities
 
-1.  **Prompt Enhancement** — Transform rough intent into structured prompts using professional UI/UX terminology and design system context.
-2.  **Design System Synthesis** — Analyze existing Stitch projects to create `.stitch/DESIGN.md` "source of truth" documents.
-3.  **Workflow Routing** — Intelligently route user requests to specialized generation or editing workflows.
-4.  **Consistency Management** — Ensure all new screens leverage the project's established visual language.
-5.  **Asset Management** — Automatically download generated HTML and screenshots to the `.stitch/designs` directory.
+1. **Prompt Enhancement** — Transform rough intent into structured prompts using professional UI or content-design terminology and project context.
+2. **Design System Synthesis** — Analyze existing Stitch projects to create `.stitch/DESIGN.md` source-of-truth documents.
+3. **Workflow Routing** — Intelligently route requests to generation, editing, or design-system workflows.
+4. **Consistency Management** — Ensure new screens, flows, or content sets leverage the project's established visual language.
+5. **Asset Management** — Download generated HTML and screenshots into `.stitch/designs` so they can be handed off to implementation workflows.
+6. **Handoff Awareness** — When the design is part of a full-stack loop, prepare output that downstream skills such as `stitch-loop` or `react:components` can use immediately.
 
 ---
 
-## 🚀 Workflows
+## Supported design modes
+
+Use this skill for any of these design targets:
+- single web pages or mobile screens
+- multi-screen flows such as onboarding, checkout, dashboards, or settings
+- reusable content systems such as social carousels, quote cards, launch graphics, or post templates
+
+If the user is designing a content series rather than an app page, think in terms of:
+- frame sequence
+- headline hierarchy
+- content density per frame
+- safe text areas and visual rhythm
+- brand consistency across all slides
+
+For a concrete content-series example, see [Xiaohongshu carousel example](examples/xiaohongshu-carousel-prompt.md).
+
+## Workflows
 
 Based on the user's request, follow one of these workflows:
 
 | User Intent | Workflow | Primary Tool |
 |:---|:---|:---|
-| "Design a [page]..." | [text-to-design](workflows/text-to-design.md) | `generate_screen_from_text` + `Download` |
-| "Edit this [screen]..." | [edit-design](workflows/edit-design.md) | `edit_screens` + `Download` |
-| "Create/Update .stitch/DESIGN.md" | [generate-design-md](workflows/generate-design-md.md) | `get_screen` + `Write` |
+| "Design a [page or post set]..." | [text-to-design](workflows/text-to-design.md) | `generate_screen_from_text` |
+| "Edit this [screen]..." | [edit-design](workflows/edit-design.md) | `edit_screens` |
+| "Create or update .stitch/DESIGN.md" | [generate-design-md](workflows/generate-design-md.md) | `get_screen` + `Write` |
 
----
+## Prompt enhancement pipeline
 
-## 🎨 Prompt Enhancement Pipeline
+Before calling any Stitch generation or editing tool, enhance the user's prompt.
 
-Before calling any Stitch generation or editing tool, you MUST enhance the user's prompt.
+### 1. Analyze context
+- **Project scope**: Maintain the current `projectId`. Use `list_projects` if unknown.
+- **Design system**: Check for `.stitch/DESIGN.md`. If it exists, incorporate its tokens. If not, suggest the `generate-design-md` workflow.
+- **Delivery target**: Identify whether the design is for a real product surface, a prototype, or a content asset set.
 
-### 1. Analyze Context
-- **Project Scope**: Maintain the current `projectId`. Use `list_projects` if unknown.
-- **Design System**: Check for `.stitch/DESIGN.md`. If it exists, incorporate its tokens (colors, typography). If not, suggest the `generate-design-md` workflow.
-
-### 2. Refine UI/UX Terminology
+### 2. Refine terminology
 Consult [Design Mappings](references/design-mappings.md) to replace vague terms.
 - Vague: "Make a nice header"
 - Professional: "Sticky navigation bar with glassmorphism effect and centered logo"
 
-### 3. Structure the Final Prompt
-Format the enhanced prompt for Stitch like this:
+For content-series requests, convert vague requests into editorial structure.
+- Vague: "Make a XiaohongShu post about market trends"
+- Professional: "Create a 6-frame mobile-first carousel with a hook cover, evidence slides, a comparison slide, and a concise CTA ending. Keep headline-safe zones large and reserve lower-third space for caption overlays."
+
+### 3. Structure the final prompt
+Format the enhanced prompt like this:
 
 ```markdown
-[Overall vibe, mood, and purpose of the page]
+[Overall vibe, mood, audience, and purpose]
 
 **DESIGN SYSTEM (REQUIRED):**
 - Platform: [Web/Mobile], [Desktop/Mobile]-first
 - Palette: [Primary Name] (#hex for role), [Secondary Name] (#hex for role)
 - Styles: [Roundness description], [Shadow/Elevation style]
 
-**PAGE STRUCTURE:**
-1. **Header:** [Description of navigation and branding]
-2. **Hero Section:** [Headline, subtext, and primary CTA]
-3. **Primary Content Area:** [Detailed component breakdown]
-4. **Footer:** [Links and copyright information]
+**OUTPUT MODE:**
+- Type: [single page / multi-screen flow / content carousel]
+- Count: [number of screens or slides if relevant]
+
+**STRUCTURE:**
+1. **Screen or Slide 1:** [Description]
+2. **Screen or Slide 2:** [Description]
+3. **Screen or Slide 3:** [Description]
 ```
 
-### 4. Present AI Insights
-After any tool call, always surface the `outputComponents` (Text Description and Suggestions) to the user.
+### 4. Present AI insights
+After any tool call, always surface the `outputComponents` text description and suggestions to the user.
+
+### 5. Prepare downstream handoff
+If the design will later be implemented or QA'd:
+- store artifacts in `.stitch/designs`
+- preserve useful screen naming or slugging
+- mention whether the next step should be `stitch-loop` or `react:components`
 
 ---
 
-## 📚 References
+## References
 
-- [Tool Schemas](references/tool-schemas.md) — How to call Stitch MCP tools.
-- [Design Mappings](references/design-mappings.md) — UI/UX keywords and atmosphere descriptors.
-- [Prompting Keywords](references/prompt-keywords.md) — Technical terms Stitch understands best.
+- [Tool Schemas](references/tool-schemas.md) for how to call Stitch MCP tools
+- [Design Mappings](references/design-mappings.md) for UI or editorial language upgrades
+- [Prompting Keywords](references/prompt-keywords.md) for technical terms Stitch understands well
 
 ---
 
-## 💡 Best Practices
+## Best practices
 
-- **Iterative Polish**: Prefere `edit_screens` for targeted adjustments over full re-generation.
-- **Semantic First**: Name colors by their role (e.g., "Primary Action") as well as their appearance.
-- **Atmosphere Matters**: Explicitly set the "vibe" (Minimalist, Vibrant, Brutalist) to guide the generator.
+- **Iterative polish**: Prefer `edit_screens` for targeted adjustments over full regeneration.
+- **Semantic first**: Name colors by their role as well as their appearance.
+- **Atmosphere matters**: Explicitly set the vibe such as minimalist, editorial, or premium.
+- **Think in systems**: For content series, maintain repeating geometry, headline rhythm, and brand-safe typography across all frames.
+- **Design for handoff**: If the design is for a real product or campaign pipeline, leave a clean trail for implementation, QA, and iteration.

--- a/skills/stitch-design/examples/fullstack-handoff.md
+++ b/skills/stitch-design/examples/fullstack-handoff.md
@@ -1,0 +1,20 @@
+# Example: Full-Stack Handoff Note
+
+Use a note like this after the design direction is accepted and the next step is implementation.
+
+## Design Status
+- Project: `market-insights-web`
+- Target: desktop landing page plus pricing page
+- Design system source: `.stitch/DESIGN.md`
+- Accepted screens: `landing-v2`, `pricing-v1`
+- Stored artifacts: `.stitch/designs/landing-v2.html`, `.stitch/designs/pricing-v1.html`
+
+## Recommended Next Step
+- Use `stitch-loop` if the project should continue through integration, browser QA, review, fix, and retest
+- Use `react:components` if the main task is converting accepted Stitch output into modular React components
+
+## Implementation Notes
+- Preserve the sticky top navigation and hero spacing from the accepted landing page
+- Keep card corner radius and CTA color consistent with `.stitch/DESIGN.md`
+- Add loading, empty, and error states that were not explicit in the design export
+- Verify the integrated result in a real browser before calling the slice done

--- a/skills/stitch-design/examples/xiaohongshu-carousel-prompt.md
+++ b/skills/stitch-design/examples/xiaohongshu-carousel-prompt.md
@@ -1,0 +1,33 @@
+# Example: XiaohongShu-Style Carousel Prompt
+
+## User Input
+> Design a XiaohongShu-style carousel post about why long-term investing beats chasing hot themes.
+
+---
+
+## Enhanced Prompt
+A mobile-first editorial carousel for a financially literate social audience. The visual tone should feel sharp, clean, confident, and easy to skim. Prioritize strong hook typography, bold contrast, and generous spacing so each slide remains readable on a phone. Avoid dashboard clutter. Make the set feel premium and trustworthy rather than hype-driven.
+
+**DESIGN SYSTEM (REQUIRED):**
+- Platform: Mobile, mobile-first
+- Palette: Graphite Black (#171717) for primary text and dark surfaces, Warm Ivory (#F8F5EF) for backgrounds, Signal Red (#E5484D) for emphasis, Sage Gray (#8B918A) for secondary labels
+- Styles: Rounded cards, soft layered shadows, bold editorial headlines, clean sans-serif body type
+
+**OUTPUT MODE:**
+- Type: content carousel
+- Count: 6 slides
+
+**STRUCTURE:**
+1. **Slide 1, Hook Cover:** Large headline, "别再追热点了" with smaller supporting line, "长期投资为什么更容易赢". Strong focal typography and one simple visual motif.
+2. **Slide 2, Problem Frame:** Explain the trap of chasing whatever is hottest right now. Use one short comparison block and one punchy supporting caption.
+3. **Slide 3, Evidence Frame:** Show that theme-chasing often means buying after the biggest move. Keep it visual and simple, with one highlighted takeaway.
+4. **Slide 4, Long-Term Logic:** Present the benefits of patient compounding, disciplined allocation, and reduced emotional trading.
+5. **Slide 5, Comparison Frame:** Side-by-side contrast between "追热点" and "长期投资" with clean visual hierarchy and quick-scan bullets.
+6. **Slide 6, Closing CTA:** End with a concise takeaway and save or follow CTA. Keep it polished and not overly promotional.
+
+---
+
+## Notes
+- Keep each slide centered on one idea.
+- Preserve consistent title, body, and footer zones across the full set.
+- Leave safe lower-third space for optional caption overlays or account branding.

--- a/skills/stitch-design/examples/xiaohongshu-content-brief.md
+++ b/skills/stitch-design/examples/xiaohongshu-content-brief.md
@@ -1,0 +1,35 @@
+# Example: XiaohongShu Content Brief
+
+## Topic
+Why long-term investing beats chasing hot themes
+
+## Audience
+Chinese-speaking retail investors who consume fast, opinionated finance content and need a clearer framework for decision-making.
+
+## Objective
+Create a mobile-first educational carousel that feels sharp, premium, and easy to save.
+
+## Tone
+Calm, confident, evidence-aware, not hype-driven.
+
+## Required CTA
+Invite the reader to save the post and follow for future breakdowns.
+
+## Inputs and materials
+- approved core message: long-term investing usually outperforms reactive theme-chasing for most non-professional investors
+- supporting examples: emotional buying after a hot move, lack of discipline, compounding over time
+- design direction: editorial, premium, readable on phone
+- constraints: no tiny charts, no clutter, no overclaiming
+
+## Slide plan
+1. **Cover**: strong hook that challenges chasing hot sectors
+2. **Problem**: explain why theme-chasing feels attractive
+3. **Cost**: show the hidden downside of buying late
+4. **Logic**: explain why long-term investing is easier to sustain
+5. **Comparison**: direct contrast between the two approaches
+6. **CTA**: concise closing takeaway plus save or follow prompt
+
+## Open questions for human approval
+- should the account feel more analytical or more creator-personal?
+- are there any approved house colors or typography constraints?
+- should this set stay purely conceptual or include specific market examples?

--- a/skills/stitch-design/references/content-system-playbook.md
+++ b/skills/stitch-design/references/content-system-playbook.md
@@ -1,0 +1,108 @@
+# Content System Playbook
+
+Use this when the design task is not just a single page, but a publishable content set such as a XiaohongShu carousel, Instagram slide post, LinkedIn carousel, quote-card series, or launch asset pack.
+
+## Goal
+
+Design the full set, not just one pretty slide. The workflow should gather materials, align with human goals, structure the story, and then turn that into a coherent visual series.
+
+## Phase 1: Discovery with humans
+
+Before prompting Stitch, identify:
+- objective of the post or series
+- target audience
+- target platform and aspect ratio expectations
+- brand style or design system
+- required CTA
+- any compliance or approval constraints
+- whether the content is educational, promotional, research-based, or narrative
+
+If any of these are missing and they materially affect the design, ask concise targeted questions.
+
+## Phase 2: Gather materials and references
+
+Collect the source inputs before designing:
+- approved facts, claims, or product copy
+- screenshots, charts, or references the human wants included
+- competitor or inspiration examples if the human has them
+- brand assets such as logos, colors, and typography rules
+- any must-cover arguments, steps, or takeaways
+
+Important:
+- do not invent factual claims that should be sourced
+- if the content depends on market, medical, legal, or product-performance claims, verify or request approved wording first
+
+## Phase 3: Create the content brief
+
+Turn the inputs into a short structured brief with:
+- title or working topic
+- audience
+- tone
+- key message
+- slide count
+- one-line purpose for each slide
+- CTA
+- constraints and assumptions
+
+A good brief should let another agent understand the whole content set without re-reading the entire conversation.
+
+## Phase 4: Define slide architecture
+
+For most social carousels, use a sequence like:
+1. hook or cover
+2. setup or problem frame
+3. evidence or explanation
+4. framework, method, or comparison
+5. takeaway or summary
+6. CTA or save/share/follow ending
+
+Not every set needs all six, but the structure should be explicit before prompting Stitch.
+
+## Phase 5: Prompt Stitch
+
+When prompting Stitch for a content set:
+- specify mobile-first if the content is for mobile social platforms
+- specify the number of slides or frames
+- define the role of each slide
+- preserve repeating title, body, and footer zones
+- keep one core idea per slide
+- leave safe space for platform chrome or branding overlays when needed
+
+## XiaohongShu-specific notes
+
+For XiaohongShu-style carousel design, default to:
+- mobile-first readability
+- strong hook cover with bold title hierarchy
+- 5 to 8 slides for a tight educational set
+- one main insight per slide
+- generous margins and clean blocks, not dashboard clutter
+- concise copy that remains legible at phone size
+- premium, editorial, or creator-native visual rhythm instead of generic presentation slides
+
+## Phase 6: Review and approval
+
+Use at least two review passes:
+
+### Internal design review
+Check:
+- readability
+- visual consistency
+- slide-to-slide pacing
+- whether any slide is too dense
+- whether the hook and CTA are strong enough
+
+### Human approval
+Get human sign-off on:
+- topic framing
+- factual claims or data usage
+- final visual direction
+- final export set before publish
+
+## Deliverables
+
+A complete handoff should include:
+- the final Stitch prompt used
+- the slide-by-slide brief
+- the generated assets or screen references
+- notes on what still needs human confirmation
+- recommended next step, such as refinement, export, or publishing

--- a/skills/stitch-design/workflows/text-to-design.md
+++ b/skills/stitch-design/workflows/text-to-design.md
@@ -4,44 +4,49 @@ description: Generate new screens from a text prompt using Stitch MCP.
 
 # Workflow: Text-to-Design
 
-Transform a text description into a high-fidelity design screen.
+Transform a text description into a high-fidelity Stitch design.
 
 ## Steps
 
-### 1. Enhance the User Prompt
-Before calling the Stitch MCP tool, apply the [Prompt Enhancement Pipeline](../SKILL.md#prompt-enhancement-pipeline). 
-- Identify the platform (Web/Mobile) and page type.
-- Incorporate any existing project design system from `.stitch/DESIGN.md`.
+### 1. Enhance the user prompt
+Before calling the Stitch MCP tool, apply the [Prompt Enhancement Pipeline](../SKILL.md#prompt-enhancement-pipeline).
+- Identify the platform and output type such as web page, mobile screen, or content carousel.
+- Incorporate any existing design system from `.stitch/DESIGN.md`.
 - Use specific [Design Mappings](../references/design-mappings.md) and [Prompting Keywords](../references/prompt-keywords.md).
+- If the design is a multi-screen set, explicitly define the number of frames or screens and the role of each one.
 
-### 2. Identify the Project
+### 2. Identify the project
 Use `list_projects` to find the correct `projectId` if it is not already known.
 
-### 3. Generate the Screen
-Call the `mcp_StitchMCP_generate_screen_from_text` tool with the enhanced prompt.
+### 3. Generate the screen or starting screen
+Call the appropriate Stitch generation tool with the enhanced prompt.
 
 ```json
 {
   "projectId": "...",
   "prompt": "[Your Enhanced Prompt]",
-  "deviceType": "DESKTOP" // or MOBILE
+  "deviceType": "DESKTOP"
 }
 ```
 
-### 4. Present AI Feedback
+Use `MOBILE` when the target is mobile UI or mobile-first content such as social carousel posts.
+
+### 4. Present AI feedback
 Always show the text description and suggestions from `outputComponents` to the user.
 
-### 5. Download Design Assets
-After generation, download the HTML and screenshot urls from `outputComponents` to the `.stitch/designs` directory.
-- **Naming**: Use the screen ID or a descriptive slug for the filename.
-- **Tools**: Use `curl -o` via `run_command` or similar.
+### 5. Download design assets
+After generation, download the HTML and screenshot URLs from `outputComponents` to `.stitch/designs`.
+- **Naming**: Use a descriptive slug, and if the request is a series, preserve slide or screen order in the filenames.
 - **Directory**: Ensure `.stitch/designs` exists.
+- **Handoff**: If the design will move into implementation, keep filenames stable so downstream skills can reuse them.
 
-### 6. Review and Refine
-- If the result is not exactly as expected, use the [edit-design](edit-design.md) workflow to make targeted adjustments.
-- Do NOT re-generate from scratch unless the fundamental layout is wrong.
+### 6. Review and refine
+- If the result is close but not right, use the [edit-design](edit-design.md) workflow.
+- Do not regenerate from scratch unless the fundamental structure is wrong.
+- If the result is part of a real delivery pipeline, hand off to `stitch-loop` or `react:components` after the design direction is accepted.
 
 ## Tips
-- **Be structural**: Break the page down into header, hero, features, and footer in your prompt.
+- **Be structural**: Break the output into sections, screens, or slides.
 - **Specify colors**: Use hex codes for precision.
-- **Set the tone**: Explicitly mention if the design should be minimal, professional, or vibrant.
+- **Set the tone**: Explicitly mention whether the design should feel minimal, editorial, premium, playful, or data-dense.
+- **For carousels**: Keep each frame focused on a single message and preserve consistent title, body, and CTA zones.

--- a/skills/stitch-design/workflows/text-to-design.md
+++ b/skills/stitch-design/workflows/text-to-design.md
@@ -14,6 +14,7 @@ Before calling the Stitch MCP tool, apply the [Prompt Enhancement Pipeline](../S
 - Incorporate any existing design system from `.stitch/DESIGN.md`.
 - Use specific [Design Mappings](../references/design-mappings.md) and [Prompting Keywords](../references/prompt-keywords.md).
 - If the design is a multi-screen set, explicitly define the number of frames or screens and the role of each one.
+- If the request is a social or research-driven content set, read [content-system-playbook](../references/content-system-playbook.md) first and gather the needed source material or human inputs before generating.
 
 ### 2. Identify the project
 Use `list_projects` to find the correct `projectId` if it is not already known.
@@ -44,6 +45,7 @@ After generation, download the HTML and screenshot URLs from `outputComponents` 
 - If the result is close but not right, use the [edit-design](edit-design.md) workflow.
 - Do not regenerate from scratch unless the fundamental structure is wrong.
 - If the result is part of a real delivery pipeline, hand off to `stitch-loop` or `react:components` after the design direction is accepted.
+- If the result is a publishable content asset, do one human-review pass on the outline or final set before treating it as final.
 
 ## Tips
 - **Be structural**: Break the output into sections, screens, or slides.

--- a/skills/stitch-loop/README.md
+++ b/skills/stitch-loop/README.md
@@ -1,6 +1,6 @@
-# Stitch Build Loop Skill
+# Stitch Full-Stack Delivery Loop Skill
 
-Teaches agents to iteratively build websites using Stitch with an autonomous baton-passing loop pattern.
+Turns Stitch into an end-to-end frontend delivery loop instead of a one-off design export.
 
 ## Install
 
@@ -10,45 +10,47 @@ npx skills add google-labs-code/stitch-skills --skill stitch-loop --global
 
 ## What It Does
 
-Enables continuous, autonomous website development through a "baton" system:
+This skill teaches an agent to run the full loop:
 
-1. Agent reads task from `next-prompt.md`
-2. Generates page via Stitch MCP tools
-3. Integrates into site structure
-4. Writes next task to continue the loop
+1. Read the current baton from `.stitch/next-prompt.md`
+2. Generate or refine the design in Stitch
+3. Pull HTML and screenshots into the repo
+4. Integrate the design into the real frontend codebase
+5. Run browser QA on the integrated app
+6. Review findings, fix issues, and retest
+7. Write the next baton so the loop continues
 
-## Prerequisites
+## What It Assumes
 
-- Stitch MCP Server access
-- A `DESIGN.md` file (generate with the `design-md` skill)
-- A `SITE.md` file for project context
+- Stitch MCP access is available, or will be set up first
+- The project keeps `.stitch/DESIGN.md`, `.stitch/SITE.md`, and `.stitch/metadata.json`
+- The generated design still needs real frontend integration work
+- Browser QA is part of the definition of done
 
-## Example Prompt
+## Key Resources
 
-```text
-Read my next-prompt.md and generate the page using Stitch, then prepare the next iteration.
-```
-
-## Skill Structure
-
-```
-stitch-loop/
-├── SKILL.md              — Core pattern instructions
-├── README.md             — This file
-├── resources/
-│   ├── baton-schema.md   — Baton file format spec
-│   └── site-template.md  — SITE.md/DESIGN.md templates
-└── examples/
-    ├── next-prompt.md    — Example baton
-    └── SITE.md           — Example site constitution
-```
+- `resources/fullstack-playbook.md` for the delivery phases and exit criteria
+- `resources/stitch-mcp-setup.md` for setting up Stitch MCP and agent access
+- `resources/openclaw-browser-qa.md` for OpenClaw and OpenCLI browser QA guidance
+- `resources/baton-schema.md` for baton format details
+- `resources/site-template.md` for bootstrapping project files
 
 ## Works With
 
-- **`design-md` skill**: Generate `DESIGN.md` from existing Stitch screens
-- **CI/CD**: GitHub Actions can trigger new iterations on push
-- **Agent chains**: Dispatch to other agents (Jules, etc.)
+- **`stitch-design`** for prompt enhancement and design-system creation
+- **`react:components`** for turning Stitch output into modular React code
+- **OpenClaw browser workflows** for browser-backed QA and fix verification
+- **CI/CD or human review** for approving each iteration before the next baton is consumed
+
+## Recommended Use
+
+Use this skill when you want Stitch to sit inside a repeatable product workflow:
+
+- product brief to screen generation
+- screen generation to app integration
+- app integration to browser QA
+- QA findings to fixes and retest
 
 ## Learn More
 
-See [SKILL.md](./SKILL.md) for complete instructions.
+See [SKILL.md](./SKILL.md) for the full operating instructions.

--- a/skills/stitch-loop/README.md
+++ b/skills/stitch-loop/README.md
@@ -23,7 +23,7 @@ This skill teaches an agent to run the full loop:
 ## What It Assumes
 
 - Stitch MCP access is available, or will be set up first
-- The project keeps `.stitch/DESIGN.md`, `.stitch/SITE.md`, and `.stitch/metadata.json`
+- The project keeps `.stitch/DESIGN.md`, `.stitch/SITE.md`, `.stitch/metadata.json`, and `.stitch/next-prompt.md`
 - The generated design still needs real frontend integration work
 - Browser QA is part of the definition of done
 

--- a/skills/stitch-loop/SKILL.md
+++ b/skills/stitch-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stitch-loop
-description: Teaches agents to iteratively build websites using Stitch with an autonomous baton-passing loop pattern
+description: Guides agents through a full Stitch design-to-code delivery loop: set up Stitch MCP access, generate or edit designs, integrate them into a frontend codebase, run browser QA, review findings, fix issues, and continue with the next iteration.
 allowed-tools:
   - "stitch*:*"
   - "chrome*:*"
@@ -9,132 +9,180 @@ allowed-tools:
   - "Bash"
 ---
 
-# Stitch Build Loop
+# Stitch Full-Stack Delivery Loop
 
-You are an **autonomous frontend builder** participating in an iterative site-building loop. Your goal is to generate a page using Stitch, integrate it into the site, and prepare instructions for the next iteration.
+Use this skill when Stitch is part of a real frontend delivery workflow, not just a one-off mockup. The goal is to move from prompt to production-ready UI through a repeatable loop:
 
-## Overview
+1. Plan the slice
+2. Generate or edit the design in Stitch
+3. Pull the design artifacts into the repo
+4. Convert the design into maintainable app code
+5. Run browser QA
+6. Fix issues and retest
+7. Write the next baton for the next iteration
 
-The Build Loop pattern enables continuous, autonomous website development through a "baton" system. Each iteration:
-1. Reads the current task from a baton file (`.stitch/next-prompt.md`)
-2. Generates a page using Stitch MCP tools
-3. Integrates the page into the site structure
-4. Writes the next task to the baton file for the next iteration
+## Read these resources when needed
 
-## Prerequisites
+- `resources/fullstack-playbook.md` for the overall operating model and exit criteria
+- `resources/stitch-mcp-setup.md` when Stitch MCP access is not ready yet
+- `resources/openclaw-browser-qa.md` when running inside OpenClaw or when browser QA should be delegated to OpenClaw browser tooling
+- `resources/baton-schema.md` for the baton contract
+- `resources/site-template.md` when bootstrapping `.stitch/SITE.md` and `.stitch/DESIGN.md`
 
-**Required:**
-- Access to the Stitch MCP Server
-- A Stitch project (existing or will be created)
-- A `.stitch/DESIGN.md` file (generate one using the `design-md` skill if needed)
-- A `.stitch/SITE.md` file documenting the site vision and roadmap
+## Default posture
 
-**Optional:**
-- Chrome DevTools MCP Server — enables visual verification of generated pages
+- Treat Stitch as a design accelerator, not the owner of your frontend architecture
+- Keep routes, state, API contracts, validation, and tests in the application repo
+- Prefer `edit_screens` or targeted follow-up generations over full regeneration when refining an existing screen
+- Do not call a slice done until browser QA has passed
+- Keep the loop alive by updating `.stitch/next-prompt.md` before you finish
 
-## The Baton System
+## Minimum project context
 
-The `.stitch/next-prompt.md` file acts as a relay baton between iterations:
+Before starting, make sure these files exist or create them:
 
-```markdown
----
-page: about
----
-A page describing how jules.top tracking works.
-
-**DESIGN SYSTEM (REQUIRED):**
-[Copy from .stitch/DESIGN.md Section 6]
-
-**Page Structure:**
-1. Header with navigation
-2. Explanation of tracking methodology
-3. Footer with links
+```text
+.stitch/
+├── metadata.json
+├── DESIGN.md
+├── SITE.md
+└── next-prompt.md
 ```
 
-**Critical rules:**
-- The `page` field in YAML frontmatter determines the output filename
-- The prompt content must include the design system block from `.stitch/DESIGN.md`
-- You MUST update this file before completing your work to continue the loop
+Helpful adjacent files outside `.stitch/`:
 
-## Execution Protocol
+```text
+docs/
+├── api-contracts.md
+├── acceptance-criteria.md
+└── frontend-architecture.md
+```
 
-### Step 1: Read the Baton
+If these docs do not exist, infer the minimum viable structure from the repo and write down any assumptions you make.
+
+## Phase 0: Confirm Stitch access
+
+1. Run `list_tools` and look for a Stitch namespace such as `stitch:` or `mcp_stitch:`
+2. If Stitch tools are missing, read `resources/stitch-mcp-setup.md` and get the MCP path working first
+3. If the repo already stores `.stitch/metadata.json`, reuse the saved `projectId` and screen metadata instead of creating a new project
+
+## Phase 1: Read the baton and project context
 
 Parse `.stitch/next-prompt.md` to extract:
-- **Page name** from the `page` frontmatter field
-- **Prompt content** from the markdown body
+- the page or feature name from frontmatter
+- the prompt body
+- any design system block copied from `.stitch/DESIGN.md`
 
-### Step 2: Consult Context Files
+Then read:
+- `.stitch/SITE.md` for roadmap, sitemap, and project intent
+- `.stitch/DESIGN.md` for visual rules
+- the app's routing, component, and API structure in the repo
+- any acceptance criteria or API contracts that constrain the slice
 
-Before generating, read these files:
+## Phase 2: Generate or edit in Stitch
 
-| File | Purpose |
-|------|---------|
-| `.stitch/SITE.md` | Site vision, **Stitch Project ID**, existing pages (sitemap), roadmap |
-| `.stitch/DESIGN.md` | Required visual style for Stitch prompts |
+Use the Stitch MCP tools to generate or update the screen.
 
-**Important checks:**
-- Section 4 (Sitemap) — Do NOT recreate pages that already exist
-- Section 5 (Roadmap) — Pick tasks from here if backlog exists
-- Section 6 (Creative Freedom) — Ideas for new pages if roadmap is empty
+### Project and metadata flow
 
-### Step 3: Generate with Stitch
+1. Discover the Stitch namespace via `list_tools`
+2. If `.stitch/metadata.json` exists, reuse `projectId`
+3. Otherwise:
+   - call `[prefix]:create_project`
+   - call `[prefix]:get_project`
+   - save the returned project metadata to `.stitch/metadata.json`
+4. After each generation or edit, call `[prefix]:get_project` again and refresh the stored `screens` map with each screen's metadata
 
-Use the Stitch MCP tools to generate the page:
+### Screen generation flow
 
-1. **Discover namespace**: Run `list_tools` to find the Stitch MCP prefix
-2. **Get or create project**: 
-   - If `.stitch/metadata.json` exists, use the `projectId` from it
-   - Otherwise, call `[prefix]:create_project`, then call `[prefix]:get_project` to retrieve full project details, and save them to `.stitch/metadata.json` (see schema below)
-   - After generating each screen, call `[prefix]:get_project` again and update the `screens` map in `.stitch/metadata.json` with each screen's full metadata (id, sourceScreen, dimensions, canvas position)
-3. **Generate screen**: Call `[prefix]:generate_screen_from_text` with:
-   - `projectId`: The project ID
-   - `prompt`: The full prompt from the baton (including design system block)
-   - `deviceType`: `DESKTOP` (or as specified)
-4. **Retrieve assets**: Before downloading, check if `.stitch/designs/{page}.html` and `.stitch/designs/{page}.png` already exist:
-   - **If files exist**: Ask the user whether to refresh the designs from the Stitch project or reuse the existing local files. Only re-download if the user confirms.
-   - **If files do not exist**: Proceed with download:
-     - `htmlCode.downloadUrl` — Download and save as `.stitch/designs/{page}.html`
-      - `screenshot.downloadUrl` — Append `=w{width}` to the URL before downloading, where `{width}` is the `width` value from the screen metadata (Google CDN serves low-res thumbnails by default). Save as `.stitch/designs/{page}.png`
+Use one of these patterns:
+- `generate_screen_from_text` for new screens
+- `edit_screens` for targeted refinements to an existing screen
+- `generate_variants` when explicitly comparing directions
 
-### Step 4: Integrate into Site
+Always keep the prompt grounded in the current design system and product constraints.
 
-1. Move generated HTML from `.stitch/designs/{page}.html` to `site/public/{page}.html`
-2. Fix any asset paths to be relative to the public folder
-3. Update navigation:
-   - Find existing placeholder links (e.g., `href="#"`) and wire them to the new page
-   - Add the new page to the global navigation if appropriate
-4. Ensure consistent headers/footers across all pages
+### Artifact sync
 
-### Step 4.5: Visual Verification (Optional)
+Before downloading, check whether these files already exist:
 
-If the **Chrome DevTools MCP Server** is available, verify the generated page:
+```text
+.stitch/designs/{page}.html
+.stitch/designs/{page}.png
+```
 
-1. **Check availability**: Run `list_tools` to see if `chrome*` tools are present
-2. **Start dev server**: Use Bash to start a local server (e.g., `npx serve site/public`)
-3. **Navigate to page**: Call `[chrome_prefix]:navigate` to open `http://localhost:3000/{page}.html`
-4. **Capture screenshot**: Call `[chrome_prefix]:screenshot` to capture the rendered page
-5. **Visual comparison**: Compare against the Stitch screenshot (`.stitch/designs/{page}.png`) for fidelity
-6. **Stop server**: Terminate the dev server process
+- If they already exist, ask whether to refresh them from Stitch or reuse them
+- If they do not exist, download them and persist them locally
+- When downloading screenshots, append `=w{width}` to the screenshot URL so the local image matches the actual screen width instead of a thumbnail
 
-> **Note:** This step is optional. If Chrome DevTools MCP is not installed, skip to Step 5.
+## Phase 3: Productionize the design in code
 
-### Step 5: Update Site Documentation
+Do not stop at copied HTML.
 
-Modify `.stitch/SITE.md`:
-- Add the new page to Section 4 (Sitemap) with `[x]`
-- Remove any idea you consumed from Section 6 (Creative Freedom)
-- Update Section 5 (Roadmap) if you completed a backlog item
+### Required productionization work
 
-### Step 6: Prepare the Next Baton (Critical)
+- map the screen into the app's actual routes or pages
+- extract reusable components instead of shipping a single giant generated file
+- move static content into data files when appropriate
+- connect forms, state, and API calls to the app's real architecture
+- add loading, empty, error, and permission states
+- preserve or translate the design tokens into the target design system
+- keep navigation, header, footer, and layout shells consistent with the rest of the app
 
-**You MUST update `.stitch/next-prompt.md` before completing.** This keeps the loop alive.
+### Handoff guidance
 
-1. **Decide the next page**: 
-   - Check `.stitch/SITE.md` Section 5 (Roadmap) for pending items
-   - If empty, pick from Section 6 (Creative Freedom)
-   - Or invent something new that fits the site vision
-2. **Write the baton** with proper YAML frontmatter:
+- Use `stitch-design` when the prompt or design system still needs work
+- Use `react:components` when the screen needs to become modular React code
+- If the project is Next.js, Astro, Vite, or another existing stack, integrate into that stack instead of creating parallel demo output
+
+## Phase 4: Browser QA is mandatory
+
+After integration, run the feature in a real browser.
+
+### Preferred browser QA path
+
+If you are running inside OpenClaw, read `resources/openclaw-browser-qa.md` and prefer the OpenClaw path:
+- use `remote-opencli` when the browser-backed run should happen through the remote OpenCLI stack
+- use `agent-browser` when deterministic click, snapshot, and interaction steps are needed
+
+### Generic fallback
+
+If OpenClaw browser tooling is not available, use Chrome DevTools MCP or the best available browser automation surface.
+
+### Minimum QA checklist
+
+- open the actual route and verify it renders
+- compare the integrated page against the Stitch screenshot for layout fidelity
+- test navigation links and route transitions
+- test forms and input validation
+- verify responsive behavior at the key widths the app supports
+- inspect obvious empty, error, and loading states
+- check browser console errors and failed network requests
+- capture issues in a short QA note before fixing them
+
+## Phase 5: Review, fix, and retest
+
+Treat QA as a loop, not a single pass.
+
+1. Convert findings into concrete fixes
+2. Patch the frontend code, not the symptom screenshot
+3. Re-run browser QA after each meaningful fix set
+4. Repeat until the slice passes visual, behavioral, and integration checks
+
+If the issue is really a design issue rather than an implementation issue, loop back to Stitch and edit the source screen, then pull the updated design back into code.
+
+## Phase 6: Update the project record
+
+Update the repo state before you finish:
+
+- refresh `.stitch/metadata.json`
+- update `.stitch/SITE.md` sitemap and roadmap
+- note any important implementation constraints or API assumptions in the repo docs
+- update `.stitch/next-prompt.md` with the next baton
+
+## Baton rules
+
+The baton file keeps the loop alive.
 
 ```markdown
 ---
@@ -143,121 +191,35 @@ page: achievements
 A competitive achievements page showing developer badges and milestones.
 
 **DESIGN SYSTEM (REQUIRED):**
-[Copy the entire design system block from .stitch/DESIGN.md]
+[Copy the relevant block from .stitch/DESIGN.md]
 
 **Page Structure:**
 1. Header with title and navigation
-2. Badge grid showing unlocked/locked states
+2. Badge grid showing locked and unlocked states
 3. Progress bars for milestone tracking
 ```
 
-## File Structure Reference
+Critical rules:
+- `page` controls the output filename
+- the body must include the design system block
+- the next baton must describe a page or slice that is not already complete in the sitemap
 
-```
-project/
-├── .stitch/
-│   ├── metadata.json   # Stitch project & screen IDs (persist this!)
-│   ├── DESIGN.md       # Visual design system (from design-md skill)
-│   ├── SITE.md         # Site vision, sitemap, roadmap
-│   ├── next-prompt.md  # The baton — current task
-│   └── designs/        # Staging area for Stitch output
-│       ├── {page}.html
-│       └── {page}.png
-└── site/public/        # Production pages
-    ├── index.html
-    └── {page}.html
-```
+## Definition of done
 
-### `.stitch/metadata.json` Schema
+A loop iteration is only done when all of these are true:
 
-This file persists all Stitch identifiers so future iterations can reference them for edits or variants. Populate it by calling `[prefix]:get_project` after creating a project or generating screens.
+- Stitch design state is saved and locally synced
+- the feature is integrated into the real app structure
+- navigation and data wiring are in place
+- browser QA has been run on the integrated result
+- discovered issues were fixed or clearly documented
+- `.stitch/SITE.md`, `.stitch/metadata.json`, and `.stitch/next-prompt.md` are up to date
 
-```json
-{
-  "name": "projects/6139132077804554844",
-  "projectId": "6139132077804554844",
-  "title": "My App",
-  "visibility": "PRIVATE",
-  "createTime": "2026-03-04T23:11:25.514932Z",
-  "updateTime": "2026-03-04T23:34:40.400007Z",
-  "projectType": "PROJECT_DESIGN",
-  "origin": "STITCH",
-  "deviceType": "MOBILE",
-  "designTheme": {
-    "colorMode": "DARK",
-    "font": "INTER",
-    "roundness": "ROUND_EIGHT",
-    "customColor": "#40baf7",
-    "saturation": 3
-  },
-  "screens": {
-    "index": {
-      "id": "d7237c7d78f44befa4f60afb17c818c1",
-      "sourceScreen": "projects/6139132077804554844/screens/d7237c7d78f44befa4f60afb17c818c1",
-      "x": 0,
-      "y": 0,
-      "width": 390,
-      "height": 1249
-    },
-    "about": {
-      "id": "bf6a3fe5c75348e58cf21fc7a9ddeafb",
-      "sourceScreen": "projects/6139132077804554844/screens/bf6a3fe5c75348e58cf21fc7a9ddeafb",
-      "x": 549,
-      "y": 0,
-      "width": 390,
-      "height": 1159
-    }
-  },
-  "metadata": {
-    "userRole": "OWNER"
-  }
-}
-```
+## Common failure modes
 
-| Field | Description |
-|-------|-------------|
-| `name` | Full resource name (`projects/{id}`) |
-| `projectId` | Stitch project ID (from `create_project` or `get_project`) |
-| `title` | Human-readable project title |
-| `designTheme` | Design system tokens: color mode, font, roundness, custom color, saturation |
-| `deviceType` | Target device: `MOBILE`, `DESKTOP`, `TABLET` |
-| `screens` | Map of page name → screen object. Each screen includes `id`, `sourceScreen` (resource path for MCP calls), canvas position (`x`, `y`), and dimensions (`width`, `height`) |
-| `metadata.userRole` | User's role on the project (`OWNER`, `EDITOR`, `VIEWER`) |
-
-## Orchestration Options
-
-The loop can be driven by different orchestration layers:
-
-| Method | How it works |
-|--------|--------------|
-| **CI/CD** | GitHub Actions triggers on `.stitch/next-prompt.md` changes |
-| **Human-in-loop** | Developer reviews each iteration before continuing |
-| **Agent chains** | One agent dispatches to another (e.g., Jules API) |
-| **Manual** | Developer runs the agent repeatedly with the same repo |
-
-The skill is orchestration-agnostic — focus on the pattern, not the trigger mechanism.
-
-## Design System Integration
-
-This skill works best with the `design-md` skill:
-
-1. **First time setup**: Generate `.stitch/DESIGN.md` using the `design-md` skill from an existing Stitch screen
-2. **Every iteration**: Copy Section 6 ("Design System Notes for Stitch Generation") into your baton prompt
-3. **Consistency**: All generated pages will share the same visual language
-
-## Common Pitfalls
-
-- ❌ Forgetting to update `.stitch/next-prompt.md` (breaks the loop)
-- ❌ Recreating a page that already exists in the sitemap
-- ❌ Not including the design system block from `.stitch/DESIGN.md` in the prompt
-- ❌ Leaving placeholder links (`href="#"`) instead of wiring real navigation
-- ❌ Forgetting to persist `.stitch/metadata.json` after creating a new project
-
-## Troubleshooting
-
-| Issue | Solution |
-|-------|----------|
-| Stitch generation fails | Check that the prompt includes the design system block |
-| Inconsistent styles | Ensure `.stitch/DESIGN.md` is up-to-date and copied correctly |
-| Loop stalls | Verify `.stitch/next-prompt.md` was updated with valid frontmatter |
-| Navigation broken | Check all internal links use correct relative paths |
+- stopping at exported HTML and calling it implementation
+- regenerating whole screens when a small edit would do
+- ignoring loading, empty, or error states
+- skipping browser QA and relying only on code inspection
+- forgetting to refresh `.stitch/metadata.json`
+- forgetting to update the baton and breaking the loop

--- a/skills/stitch-loop/resources/fullstack-playbook.md
+++ b/skills/stitch-loop/resources/fullstack-playbook.md
@@ -1,0 +1,96 @@
+# Stitch Full-Stack Playbook
+
+Use this playbook when Stitch is part of a real frontend build cycle.
+
+## Inputs to gather before each slice
+
+Minimum inputs:
+- product or feature brief
+- route or page name
+- target device priorities
+- acceptance criteria
+- data or API dependencies
+- current `.stitch/DESIGN.md`
+- current `.stitch/SITE.md`
+
+Helpful extras:
+- `docs/api-contracts.md`
+- `docs/frontend-architecture.md`
+- design token files
+- auth and permission rules
+
+## Phase 1: Frame the slice
+
+Before touching Stitch, answer these questions:
+- What route or user flow is being built?
+- What does success look like?
+- What data does the page need?
+- Which states must exist besides the happy path?
+- Is this a brand new screen, a refinement, or a code-only fix?
+
+## Phase 2: Generate or refine the design
+
+Use Stitch to:
+- generate a new screen from a structured prompt
+- edit an existing screen with a precise follow-up prompt
+- create variants only when a real decision is needed
+
+Keep a stable design system. Do not change the visual language casually from slice to slice.
+
+## Phase 3: Pull the design into the repo
+
+Persist:
+- `.stitch/metadata.json`
+- `.stitch/designs/{page}.html`
+- `.stitch/designs/{page}.png`
+
+Keep the downloaded design artifacts as staging material, not the final architecture.
+
+## Phase 4: Productionize
+
+Expected productionization work:
+- split generated markup into maintainable components
+- align styles with the app's token system
+- wire routing, forms, state, and data fetching
+- add accessibility affordances and interaction states
+- preserve reusable layout shells and navigation
+- remove placeholder data when the app has real data sources
+
+## Phase 5: Browser QA
+
+A slice is not done until it has been exercised in a browser.
+
+Check at minimum:
+- visual fidelity against the Stitch screenshot
+- route rendering and navigation
+- responsive behavior
+- console and network failures
+- form behavior and validation
+- loading, empty, and error states
+
+If you are inside OpenClaw, prefer the OpenClaw browser workflow described in `openclaw-browser-qa.md`.
+
+## Phase 6: Fix and retest
+
+Use a tight loop:
+1. capture findings
+2. fix the underlying code issue
+3. rerun browser QA
+4. only loop back to Stitch if the problem is fundamentally a design issue
+
+## Phase 7: Prepare the next iteration
+
+Before ending the slice:
+- update `.stitch/SITE.md`
+- refresh `.stitch/metadata.json`
+- write the next baton in `.stitch/next-prompt.md`
+- note any architectural or API assumptions in repo docs
+
+## Exit criteria
+
+Do not mark the slice done unless all of these are true:
+- design synced locally
+- real app code updated
+- browser QA performed
+- major findings fixed or documented
+- baton updated

--- a/skills/stitch-loop/resources/openclaw-browser-qa.md
+++ b/skills/stitch-loop/resources/openclaw-browser-qa.md
@@ -6,9 +6,11 @@ Use this guide when the Stitch loop runs inside OpenClaw and browser QA should b
 
 Use OpenClaw browser workflows instead of treating browser QA as optional.
 
+`remote-opencli` and `agent-browser` are external OpenClaw skills, not files bundled in this repository.
+
 ### Default split of responsibilities
 
-- Use the `remote-opencli` skill when the browser-backed work should run through the remote OpenCLI stack on the Mac mini
+- Use the `remote-opencli` skill when the browser-backed work should run through a remote OpenCLI stack
 - Use the `agent-browser` skill when you need deterministic interaction with a live browser session, including open, snapshot, and act steps
 
 This split works well because `remote-opencli` is good for remote browser-backed orchestration and `agent-browser` is good for precise page interaction.
@@ -23,9 +25,10 @@ This split works well because `remote-opencli` is good for remote browser-backed
 6. Compare the integrated result against the Stitch screenshot
 7. Record issues, fix them in code, and rerun the same browser checks
 
-## `agent-browser` defaults
+## `agent-browser` example defaults
 
-When using the OpenClaw browser tool path, prefer these defaults:
+When using the OpenClaw browser tool path, prefer stable node-backed browser settings for your environment.
+For example, one OpenClaw setup might use:
 - `target: "node"`
 - `node: "Mac-Mini-Node"`
 - `profile: "openclaw"`
@@ -39,16 +42,17 @@ Typical sequence:
 
 If the browser session drops, restart it with the same profile and continue.
 
-## `remote-opencli` defaults
+## `remote-opencli` example defaults
 
-Use the verified Mac mini route unless the user asks otherwise:
+Use the remote OpenCLI host and PATH for your own environment.
+For example, one setup might use:
 - SSH target: `xlmini@xlmini`
 - prepend `PATH="/opt/homebrew/bin:$HOME/.bun/bin:$PATH"`
 - verify with `opencli --version` and `opencli doctor`
 
 Use this route when:
 - the QA job is remote or long-running
-- the page needs a real logged-in browser context on the Mac
+- the page needs a real logged-in browser context on the remote machine
 - the work should be checked later instead of busy polling
 
 ## What to test in browser QA

--- a/skills/stitch-loop/resources/openclaw-browser-qa.md
+++ b/skills/stitch-loop/resources/openclaw-browser-qa.md
@@ -1,0 +1,86 @@
+# OpenClaw Browser QA Guide
+
+Use this guide when the Stitch loop runs inside OpenClaw and browser QA should be part of the implementation loop.
+
+## Preferred OpenClaw path
+
+Use OpenClaw browser workflows instead of treating browser QA as optional.
+
+### Default split of responsibilities
+
+- Use the `remote-opencli` skill when the browser-backed work should run through the remote OpenCLI stack on the Mac mini
+- Use the `agent-browser` skill when you need deterministic interaction with a live browser session, including open, snapshot, and act steps
+
+This split works well because `remote-opencli` is good for remote browser-backed orchestration and `agent-browser` is good for precise page interaction.
+
+## Recommended QA sequence
+
+1. Start the app locally or obtain the preview URL
+2. If the run should happen through the remote Mac browser stack, use `remote-opencli` first to verify the remote OpenCLI environment is healthy
+3. Open the target page in the browser session
+4. Capture a snapshot before making assertions
+5. Click through the real user flow
+6. Compare the integrated result against the Stitch screenshot
+7. Record issues, fix them in code, and rerun the same browser checks
+
+## `agent-browser` defaults
+
+When using the OpenClaw browser tool path, prefer these defaults:
+- `target: "node"`
+- `node: "Mac-Mini-Node"`
+- `profile: "openclaw"`
+
+Typical sequence:
+- browser status
+- browser start
+- browser open
+- browser snapshot
+- browser act
+
+If the browser session drops, restart it with the same profile and continue.
+
+## `remote-opencli` defaults
+
+Use the verified Mac mini route unless the user asks otherwise:
+- SSH target: `xlmini@xlmini`
+- prepend `PATH="/opt/homebrew/bin:$HOME/.bun/bin:$PATH"`
+- verify with `opencli --version` and `opencli doctor`
+
+Use this route when:
+- the QA job is remote or long-running
+- the page needs a real logged-in browser context on the Mac
+- the work should be checked later instead of busy polling
+
+## What to test in browser QA
+
+At minimum:
+- route loads correctly
+- navigation works
+- forms validate correctly
+- loading, empty, and error states behave sensibly
+- responsive layout holds at supported widths
+- console is clean enough for the feature under test
+- failed network requests are understood
+- visual structure still matches the Stitch design intent
+
+## How to use the results
+
+A browser QA pass should produce one of two outputs:
+
+### Pass
+- route verified
+- key interactions verified
+- no blocking visual or functional issues
+
+### Fix loop
+- issue summary
+- reproduction path
+- expected behavior
+- actual behavior
+- screenshots or snapshots if helpful
+
+Then patch the code and rerun the same browser checks.
+
+## Fallback
+
+If OpenClaw browser tooling is not available in the current environment, use Chrome DevTools MCP or the best available browser automation surface. Do not skip browser QA just because the preferred path is unavailable.

--- a/skills/stitch-loop/resources/site-template.md
+++ b/skills/stitch-loop/resources/site-template.md
@@ -25,8 +25,9 @@ Use these templates when setting up a new project for the build loop.
     * *Tertiary:* [Additional flavor]
 
 ## 3. Architecture & File Structure
-* **Root:** `site/public/`
-* **Asset Flow:** Stitch generates to `queue/` → Validate → Move to `site/public/`
+* **App Root:** [Your real frontend app root, such as `app/`, `src/`, or `site/`]
+* **Stitch Staging:** Store downloaded Stitch artifacts in `.stitch/designs/`
+* **Integration Flow:** Stitch generates design artifacts → review and validate them → integrate them into the app's real routes, components, and data layer
 * **Navigation Strategy:** [How nav works]
 
 ## 4. Live Sitemap (Current State)
@@ -60,7 +61,7 @@ Use these templates when setting up a new project for the build loop.
 
 ## 7. Rules of Engagement
 1. Do not recreate pages in Section 4
-2. Always update `next-prompt.md` before completing
+2. Always update `.stitch/next-prompt.md` before completing
 3. Consume ideas from Section 6 when you use them
 ```
 

--- a/skills/stitch-loop/resources/stitch-mcp-setup.md
+++ b/skills/stitch-loop/resources/stitch-mcp-setup.md
@@ -1,0 +1,148 @@
+# Stitch MCP Setup Guide
+
+Use this guide when the skill needs Stitch access but the agent cannot see Stitch tools yet.
+
+## Choose the integration path
+
+There are two practical paths:
+
+### 1. Agent-facing MCP path
+
+Use this when Claude Code, Cursor, Gemini CLI, Codex, OpenCode, or another coding agent should call Stitch tools directly.
+
+A practical local proxy is `@_davideast/stitch-mcp`, which can expose Stitch through a local stdio MCP server.
+
+Fast path:
+
+```bash
+npx @_davideast/stitch-mcp init
+```
+
+That flow can set up auth, gcloud, and MCP client configuration.
+
+Typical MCP server entry:
+
+```json
+{
+  "mcpServers": {
+    "stitch": {
+      "command": "npx",
+      "args": ["@_davideast/stitch-mcp", "proxy"]
+    }
+  }
+}
+```
+
+If you already use a system `gcloud` profile and want to reuse it:
+
+```json
+{
+  "mcpServers": {
+    "stitch": {
+      "command": "npx",
+      "args": ["@_davideast/stitch-mcp", "proxy"],
+      "env": {
+        "STITCH_USE_SYSTEM_GCLOUD": "1"
+      }
+    }
+  }
+}
+```
+
+### 2. SDK path
+
+Use this when you are writing your own scripts, services, or orchestration code instead of connecting a coding agent through a local MCP config.
+
+Install the official SDK:
+
+```bash
+npm install @google/stitch-sdk
+```
+
+Minimal example:
+
+```ts
+import { stitch } from "@google/stitch-sdk";
+
+const project = stitch.project("your-project-id");
+const screen = await project.generate("A dashboard with charts", "DESKTOP");
+const htmlUrl = await screen.getHtml();
+const imageUrl = await screen.getImage();
+```
+
+## Authentication options
+
+### API key path
+
+If you have a Stitch API key, set:
+
+```bash
+export STITCH_API_KEY="your-api-key"
+```
+
+This is the simplest path for direct SDK use and can also simplify local proxy use.
+
+### OAuth plus Google Cloud project path
+
+Some setups use OAuth plus a Google Cloud project context instead of an API key.
+
+Common environment variables you may see:
+- `STITCH_ACCESS_TOKEN`
+- `GOOGLE_CLOUD_PROJECT`
+- `STITCH_PROJECT_ID`
+- `STITCH_HOST`
+
+For local proxy flows that lean on `gcloud`, follow the proxy tool's auth steps or the official Stitch docs.
+
+## Verification checklist
+
+After setup, verify the connection before trying to use any Stitch skill.
+
+### If you use the local proxy
+
+```bash
+npx @_davideast/stitch-mcp doctor
+npx @_davideast/stitch-mcp tool
+```
+
+You want to see a healthy doctor result and a tool list that includes core Stitch operations such as:
+- `create_project`
+- `generate_screen_from_text`
+- `get_project`
+- `get_screen`
+- `edit_screens`
+
+### If you use a coding agent client
+
+Run the agent's tool discovery step and confirm the Stitch namespace is visible. The skills in this repo usually assume a namespace like:
+- `stitch:`
+- `mcp_stitch:`
+
+### If you use the SDK directly
+
+Write a quick smoke test that lists projects or retrieves screens for a known project.
+
+## Troubleshooting
+
+If setup fails, check these first:
+- billing is enabled on the Google Cloud project
+- the Stitch API is enabled
+- the authenticated user has Owner or Editor access
+- the OAuth flow actually completed
+- the agent process received the needed env vars
+
+Environment caveat:
+- WSL, SSH sessions, Docker containers, and Cloud Shell may not open a browser automatically for auth. In those cases, copy the printed OAuth URL into a browser manually.
+
+## Recommended references
+
+Keep these links handy and verify details against the latest docs:
+- `https://stitch.withgoogle.com/docs/mcp/setup`
+- `https://stitch.withgoogle.com/docs/mcp/guide/`
+- `https://stitch.withgoogle.com/docs/sdk/agent-workflows/`
+
+## Notes
+
+- The official SDK package is `@google/stitch-sdk`
+- A local proxy such as `@_davideast/stitch-mcp` is useful when an agent expects a local MCP server process
+- Always confirm the actual visible tool names in your environment before hardcoding prefixes in prompts or scripts


### PR DESCRIPTION
## Summary
- expand `stitch-loop` from a page generator into a fuller design-to-code-to-QA loop
- add Stitch MCP setup guidance and OpenClaw/OpenCLI browser QA guidance
- align templates and docs around `.stitch/designs` staging and `.stitch/next-prompt.md`
- enhance `stitch-design` for content systems, handoff awareness, and social carousel use cases
- add new examples for XiaohongShu-style carousel prompts and full-stack handoff notes

## What changed
### `stitch-loop`
- clarified the full delivery loop: design, integration, browser QA, fix, retest
- added `resources/fullstack-playbook.md`
- added `resources/stitch-mcp-setup.md`
- added `resources/openclaw-browser-qa.md`
- fixed template and README inconsistencies found during review

### `stitch-design`
- broadened the skill to cover web pages, app flows, and reusable content layouts
- improved the text-to-design workflow for multi-screen and mobile-first content outputs
- added examples for social carousel prompting and implementation handoff

## Notes
- this PR keeps the existing skills and extends them rather than introducing a separate new skill
- no code-path tests were required because the changes are documentation, skill instructions, and examples only
