### PR TITLE
fix(docs): replace broken labs.google.com/stitch URL with stitch.withgoogle.com

### DIFF
--- a/skills/taste-design/SKILL.md
+++ b/skills/taste-design/SKILL.md
@@ -15,7 +15,7 @@ This skill generates `DESIGN.md` files optimized for Google Stitch screen genera
 The generated `DESIGN.md` serves as the **single source of truth** for prompting Stitch to generate new screens that align with a curated, high-agency design language. Stitch interprets design through **"Visual Descriptions"** supported by specific color values, typography specs, and component behaviors.
 
 ## Prerequisites
-- Access to Google Stitch via [labs.google.com/stitch](https://labs.google.com/stitch)
+- Access to Google Stitch via [stitch.withgoogle.com](https://stitch.withgoogle.com/)
 - Optionally: Stitch MCP Server for programmatic integration with Cursor, Antigravity, or Gemini CLI
 
 ## The Goal


### PR DESCRIPTION
## Summary
- Replace broken URL `https://labs.google.com/stitch` (returns 404) with working URL `https://stitch.withgoogle.com/`

## Why
Issue #48 reports that the `labs.google.com/stitch` URL leads to a 404 error. Google Stitch is accessible at `stitch.withgoogle.com`.

## Validation
- Verified `stitch.withgoogle.com` returns the Google Stitch page

## Related
- Fixes #48