### PR TITLE
fix: replace colon with hyphen in react:components skill name

### DIFF
--- a/plugins/stitch-build/skills/react-components/SKILL.md
+++ b/plugins/stitch-build/skills/react-components/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: react:components
+name: react-components
 description: Converts Stitch designs into modular Vite and React components using system-level networking and AST-based validation.
 allowed-tools:
   - "stitch*:*"


### PR DESCRIPTION
Closes #39

The colon in `react:components` causes the skill to fail loading in copilot-cli. Replaced with a hyphen to comply with the skill name validation rule.