### PR TITLE
fix(react-components): detect hex colors in JSX className (validator was a no-op)

### DIFF
--- a/plugins/stitch-build/skills/react-components/scripts/validate.js
+++ b/plugins/stitch-build/skills/react-components/scripts/validate.js
@@ -33,7 +33,7 @@ async function validateComponent(filePath) {
     const walk = (node) => {
       if (!node) return;
       if (node.type === 'TsInterfaceDeclaration' && node.id.value.endsWith('Props')) hasInterface = true;
-      if (node.type === 'JSXAttribute' && node.name.name === 'className') {
+      if (node.type === 'JSXAttribute' && (node.name?.value === 'className' || node.name?.name === 'className')) {
         if (node.value?.value && HEX_COLOR_REGEX.test(node.value.value)) tailwindIssues.push(node.value.value);
       }
       for (const key in node) { if (node[key] && typeof node[key] === 'object') walk(node[key]); }


### PR DESCRIPTION
## What

The hex-color rule in `plugins/stitch-build/skills/react-components/scripts/validate.js` is silently a no-op. The guard at line 36 reads `node.name.name === 'className'`, but SWC's AST exposes the JSXAttribute identifier on `.name.value`. The condition is always false, so the inner regex test never runs and `tailwindIssues` stays empty regardless of input.

## Why it matters

`validate.js` is the heart of the `react-components` skill's quality gate. The Props-interface rule works correctly; the hex rule does not. Today, components like

```tsx
export function Card({ title }: CardProps) {
  return <div className="bg-[#ff0000] text-[#ffffff]">{title}</div>;
}
```

pass validation with `✅ No hardcoded hex values found.` even though the whole point of the check is to catch exactly this pattern. The CI smoke test stays green because [`gold-standard-card.tsx`](https://github.com/google-labs-code/stitch-skills/blob/main/plugins/stitch-build/skills/react-components/examples/gold-standard-card.tsx) has no hex codes, so the failing rule never gets exercised in CI.

## Fix

One-line change: accept both AST shapes so the guard works against the current SWC release and stays correct if a future revision flips the field back. Optional chaining added so a malformed node can't NPE the walker.

```diff
- if (node.type === 'JSXAttribute' && node.name.name === 'className') {
+ if (node.type === 'JSXAttribute' && (node.name?.value === 'className' || node.name?.name === 'className')) {
```

## Reproducer

Before this patch:

```bash
cd plugins/stitch-build/skills/react-components
npm ci
cat > /tmp/bad.tsx << 'EOF'
export function X() { return <div className="bg-[#ff0000]">x</div>; }
EOF
node scripts/validate.js /tmp/bad.tsx
# → "✅ No hardcoded hex values found." (wrong — exits with Props failure only)
```

After this patch, the same input correctly reports `❌ STYLE: Found 1 hardcoded hex codes.` and exits 1.

The existing `examples/gold-standard-card.tsx` continues to validate clean, so the CI workflow is unaffected.

## Verification I ran locally

- `npm ci` clean (4 packages, 0 vulnerabilities, Node 20.19.4)
- Positive: `node scripts/validate.js examples/gold-standard-card.tsx` → `✨ COMPONENT VALID.` exit 0
- Negative (Props missing + hex codes): exit 1, both rules now fire (was: only Props rule fired)
- 10-second smoke loop hammering the validator: 168 iterations, 0 failures

Happy to add a negative-test fixture and wire it into `.github/workflows/validate-skills.yml` in a follow-up if that's wanted.
