### PR TITLE
feat(stitch-design): add markdown upload support and generated-by pro…

### DIFF
--- a/plugins/stitch-design/skills/code-to-design/SKILL.md
+++ b/plugins/stitch-design/skills/code-to-design/SKILL.md
@@ -62,7 +62,8 @@ Delegate to the `manage-design-system` skill to upload the `DESIGN.md` and
 create the design system in Stitch. Read
 [skills/manage-design-system/SKILL.md](../manage-design-system/SKILL.md) for
 the full workflow (upload script usage, `create_design_system_from_design_md`
-call, and required schemas).
+call, and required schemas). Pass
+`--generated-by 'stitch::code-to-design'` when uploading.
 
 #### 5. Upload HTML to Stitch
 
@@ -73,3 +74,4 @@ You will need:
 - The path to the standalone HTML file generated in Step 1.
 - Your Stitch API Key (same key used in Step 4).
 - The target `projectId`.
+- The `--generated-by` argument set to `'stitch::extract-static-html'`.

--- a/plugins/stitch-design/skills/manage-design-system/SKILL.md
+++ b/plugins/stitch-design/skills/manage-design-system/SKILL.md
@@ -68,8 +68,15 @@ design system in Stitch.
      python3 stitch-skills/plugins/stitch-design/skills/upload-to-stitch/scripts/upload_to_stitch.py \
        --project-id <PROJECT_ID> \
        --file-path /path/to/DESIGN.md \
-       --api-key <API_KEY>
+       --api-key <API_KEY> \
+       --generated-by <GENERATED_BY>
      ```
+     Set `<GENERATED_BY>` to identify the skill or tool that produced the
+     `DESIGN.md`. Use the calling skill name when invoked from another skill
+     (e.g. `stitch::code-to-design`), or the agent/tool name for standalone
+     use (e.g. `Gemini`, `Claude Code`). If omitted, the script defaults to
+     `UserUploadedDesignMd`.
+
      This returns the `sourceScreen` ID and the `screenInstance` ID.
    - **Option B (Direct MCP Tool)**: If the `DESIGN.md` is small (under ~5KB), you can call the `upload_design_md` MCP tool directly, passing the base64-encoded design markdown content as `designMdBase64`.
 2. **Create Design System**: Call the `create_design_system_from_design_md` tool immediately after the upload, passing the `projectId` and the `selectedScreenInstance` (containing the `id` and `sourceScreen` returned from the upload step).

--- a/plugins/stitch-design/skills/upload-to-stitch/SKILL.md
+++ b/plugins/stitch-design/skills/upload-to-stitch/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: stitch::upload-to-stitch
 description: >-
-  Upload local assets (images, mockups, extracted HTML) to a Stitch project.
-  ALWAYS use this skill when you need to upload visual assets or full HTML pages
+  Upload local assets (images, mockups, extracted HTML, design markdown) to a Stitch project.
+  ALWAYS use this skill when you need to upload visual assets, HTML pages, or design docs
   to Stitch, particularly when direct MCP tool calls fail or truncate due to
   base64 token limits.
 allowed-tools:
@@ -15,7 +15,7 @@ allowed-tools:
 
 # Upload-to-Stitch
 
-Upload local assets (images, mockups, HTML files) to a Stitch project using the
+Upload local assets (images, mockups, HTML, and markdown files) to a Stitch project using the
 provided upload script, which bypasses the MCP tool's base64 output token limits.
 
 > [!NOTE]
@@ -60,18 +60,23 @@ python3 <SKILL_DIR>/scripts/upload_to_stitch.py \
   --file-path <PATH_TO_FILE> \
   --api-key <API_KEY> \
   [--api-url <STITCH_API_URL>] \
-  [--title <SCREEN_TITLE>]
+  [--title <SCREEN_TITLE>] \
+  [--generated-by <GENERATED_BY>]
 ```
 
 > [!TIP]
 > **macOS / SSL Certificate Troubleshooting:**
 > If the upload fails with `ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] unable to get local issuer certificate`, this means your Python installation does not have root certificate authorities configured.
-> Fix it by prepending `SSL_CERT_FILE` using the `certifi` bundle:
+> 
+> The script automatically attempts to use the `certifi` package to load the CA bundle if it is installed in your python environment. If `certifi` is not installed, you can either install it (`pip install certifi`) or manually supply the `SSL_CERT_FILE` environment variable when running the script:
 > ```bash
 > SSL_CERT_FILE=$(python3 -c "import certifi; print(certifi.where())") python3 <SKILL_DIR>/scripts/upload_to_stitch.py \
 >   --project-id <PROJECT_ID> \
 >   --file-path <PATH_TO_FILE> \
->   --api-key <API_KEY>
+>   --api-key <API_KEY> \
+>   [--api-url <STITCH_API_URL>] \
+>   [--title <SCREEN_TITLE>] \
+>   [--generated-by <GENERATED_BY>]
 > ```
 
 ### Supported File Types
@@ -82,12 +87,15 @@ python3 <SKILL_DIR>/scripts/upload_to_stitch.py \
 | `.jpg`, `.jpeg` | `image/jpeg` |
 | `.webp` | `image/webp` |
 | `.html`, `.htm` | `text/html` |
+| `.md` | `text/markdown` |
 
 The script auto-detects MIME type from the file extension.
 
-### Script Defaults
+### Script Options
 
-- `--api-url` defaults to `https://stitch.googleapis.com`
-- `--api-key` is **required**
-- Screen instances are automatically created for display
-- For HTML files, `screenType` is set to `DOCUMENT`; for images, `IMAGE`
+- `--project-id`: **Required**. The Stitch project ID.
+- `--file-path`: **Required**. Path to the local file to upload.
+- `--api-key`: **Required**. API key for Stitch authorization.
+- `--api-url`: Optional. Base URL of the Stitch API. Defaults to `https://stitch.googleapis.com`.
+- `--title`: Optional. Title for the uploaded screen.
+- `--generated-by`: Optional. Specify how the uploaded file was generated (e.g., 'stitch::extract-static-html' skill, 'Claude Code', 'Codex', 'Gemini' etc.).

--- a/plugins/stitch-design/skills/upload-to-stitch/scripts/upload_to_stitch.py
+++ b/plugins/stitch-design/skills/upload-to-stitch/scripts/upload_to_stitch.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-r"""Upload an image or HTML to a Stitch project via BatchCreateScreens.
+r"""Upload an image, HTML, or Markdown file to a Stitch project via BatchCreateScreens.
 
 WHY THIS SCRIPT EXISTS:
     The AI model cannot upload files via the MCP tool directly because MCP tool
@@ -16,6 +16,7 @@ WHY THIS SCRIPT EXISTS:
 SUPPORTED FILE TYPES:
     - Images: .png, .jpg, .jpeg, .webp
     - HTML: .html, .htm
+    - Markdown: .md
 
 Usage:
     python3 upload_to_stitch.py \
@@ -24,6 +25,7 @@ Usage:
         [--api-url <STITCH_API_BASE_URL>] \
         [--api-key <API_KEY>] \
         [--title <SCREEN_TITLE>] \
+        [--generated-by <GENERATED_BY>] \
         [--create-screen-instances]
 """
 
@@ -34,6 +36,13 @@ import pathlib
 import sys
 from typing import Any
 import urllib.request
+
+try:
+  import ssl
+  import certifi
+  _SSL_CONTEXT = ssl.create_default_context(cafile=certifi.where())
+except ImportError:
+  _SSL_CONTEXT = None
 
 
 # Maps file extensions to MIME types.
@@ -98,7 +107,10 @@ def call_batch_create_screens(
 
   try:
     print("Calling urlopen...")
-    with urlopen(req, timeout=120) as resp:
+    urlopen_kwargs = {"timeout": 120}
+    if _SSL_CONTEXT is not None:
+      urlopen_kwargs["context"] = _SSL_CONTEXT
+    with urlopen(req, **urlopen_kwargs) as resp:
       print(f"urlopen returned. Status: {resp.getcode()}")
       body = resp.read().decode("utf-8")
       print(f"Response status: {resp.getcode()}")
@@ -118,6 +130,7 @@ def build_screen_request(
     mime_type: str,
     b64_data: str,
     title: str | None = None,
+    generated_by: str | None = None,
 ) -> dict[str, Any]:
   """Build a CreateScreenRequest dict from a file.
 
@@ -128,6 +141,7 @@ def build_screen_request(
     mime_type: The MIME type of the file.
     b64_data: Base64-encoded file content.
     title: Optional title for the screen.
+    generated_by: Optional value for the generatedBy field (HTML/markdown only).
 
   Returns:
     A CreateScreenRequest-shaped dict.
@@ -143,6 +157,13 @@ def build_screen_request(
         "screenType": "DOCUMENT",
         "isCreatedByClient": True,
     }
+    if not generated_by:
+      if mime_type == "text/markdown":
+        generated_by = "UserUploadedDesignMd"
+      elif mime_type == "text/html":
+        generated_by = "UserUploadedHtml"
+    if generated_by:
+      screen["generatedBy"] = generated_by
   else:
     screen = {
         "screenshot": file_obj,
@@ -186,6 +207,14 @@ def parse_args():
       default=None,
       help="Optional title for the created screen",
   )
+  parser.add_argument(
+      "--generated-by",
+      default=None,
+      help=(
+          "Value for the generatedBy field in the screen proto"
+          " (HTML/markdown uploads only)."
+      ),
+  )
   return parser.parse_args()
 
 
@@ -207,13 +236,18 @@ def main():
     print(f"Error: File not found: {file_path}")
     sys.exit(1)
 
+  if args.generated_by and mime_type not in ("text/html", "text/markdown"):
+    print("Warning: --generated-by is ignored for image uploads.")
+
   print(f"File:      {file_path}")
   print(f"MIME type: {mime_type}")
 
   b64_data = encode_file(file_path)
   print(f"Base64:    {len(b64_data)} chars")
 
-  screen_request = build_screen_request(mime_type, b64_data, title=args.title)
+  screen_request = build_screen_request(
+      mime_type, b64_data, title=args.title, generated_by=args.generated_by,
+  )
 
   print(f"\nUploading to project: {args.project_id}")
   print(f"API URL:   {args.api_url}")


### PR DESCRIPTION
…venance tracking

- upload_to_stitch.py: Add .md extension / text/markdown MIME mapping
- upload_to_stitch.py: Add --generated-by argument to set the generatedBy field on HTML/Markdown screens
- upload_to_stitch.py: Add warning when --generated-by is passed on image uploads (ignored)
- upload_to_stitch.py: Define global SSL context using certifi.where() fallback if package is available
- upload-to-stitch/SKILL.md: Add .md to supported formats and document new CLI options
- code-to-design/SKILL.md: Update Steps 4 & 5 to pass --generated-by with corresponding skill identifiers
- manage-design-system/SKILL.md: Update DESIGN.md upload example with --generated-by <GENERATED_BY> placeholder and document how to set it