### PR TITLE
feat(build): react-vite-dashboard agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ npx skills --help
 
 These skills require the **Stitch MCP** server to be configured and running in your agent's environment. Make sure you have followed the [Stitch MCP Setup Instructions](https://stitch.withgoogle.com/docs/mcp/setup/) to register the server and set up appropriate environment variables and credentials.
 
+> **Docs navigation:** If a link on [stitch.withgoogle.com/docs](https://stitch.withgoogle.com/docs/) redirects incorrectly, open the target path under the same host (e.g. `https://stitch.withgoogle.com/docs/learn/device-types/`).
+
 ## Available Plugins
 
 ### Design (`stitch-design`)
@@ -108,6 +110,7 @@ Code generation, framework integration, and asset compilation from Stitch design
 | [remotion](plugins/stitch-build/skills/remotion/) | Generate walkthrough videos from Stitch projects using Remotion with smooth transitions and zooming | *"Generate a walkthrough video of the Stitch project `projects/456`."* |
 | [react-native](plugins/stitch-build/skills/react-native/) | Convert Stitch HTML designs to production-ready React Native components with StyleSheet and platform-specific code | *"Convert the Stitch design to React Native components with proper theme and navigation."* |
 | [shadcn-ui](plugins/stitch-build/skills/shadcn-ui/) | Expert guidance for integrating and building applications with shadcn/ui components | *"Set up shadcn/ui and build a data table with sorting and filtering."* |
+| [react-vite-dashboard](plugins/stitch-build/skills/react-vite-dashboard/) | Convert Stitch screens to React + Vite dashboards with TanStack Query, DESIGN.md tokens, and Web3 read patterns | *"Build a DeFi portfolio dashboard from this Stitch screen using our DESIGN.md."* |
 
 ---
 
@@ -140,6 +143,7 @@ plugins/
 │   └── skills/
 │       ├── react-components/    — stitch::react-components
 │       ├── react-native/
+│       ├── react-vite-dashboard/
 │       ├── remotion/
 │       └── shadcn-ui/
 └── stitch-utilities/       — Design utilities & assistants plugin

--- a/plugins/stitch-build/plugin.json
+++ b/plugins/stitch-build/plugin.json
@@ -14,6 +14,7 @@
     "components",
     "remotion",
     "shadcn-ui",
+    "react-vite-dashboard",
     "code-generation",
     "video"
   ]

--- a/plugins/stitch-build/skills/react-vite-dashboard/README.md
+++ b/plugins/stitch-build/skills/react-vite-dashboard/README.md
@@ -1,0 +1,24 @@
+# React + Vite Dashboard Skill
+
+Convert Stitch screens into production React dashboards with Vite, TanStack Query, and optional Web3 reads.
+
+## Install
+
+```bash
+npx skills add google-labs-code/stitch-skills --skill react-vite-dashboard --global
+```
+
+## Example prompts
+
+```
+Convert the Stitch dashboard screen into React + Vite components using our DESIGN.md tokens
+```
+
+```
+Wire the portfolio summary cards with TanStack Query and ethers read-only calls
+```
+
+## Related skills
+
+- `design-md` — author and lint DESIGN.md before building UI
+- `shadcn-ui` — add accessible component primitives on top of generated layouts

--- a/plugins/stitch-build/skills/react-vite-dashboard/SKILL.md
+++ b/plugins/stitch-build/skills/react-vite-dashboard/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: react-vite-dashboard
+description: Convert Stitch designs into production React + Vite dashboards with TanStack Query, accessible tokens from DESIGN.md, and Web3-ready patterns (ethers/viem).
+allowed-tools:
+  - "stitch*:*"
+  - "Read"
+  - "Write"
+  - "Bash"
+  - "web_fetch"
+---
+
+# Stitch to React + Vite Dashboard
+
+You are a frontend engineer building **data-dense dashboards** from Stitch screens. Target stack: **React 18**, **Vite**, **TypeScript**, **TanStack Query**, **React Router**, and optional **ethers v6** or **viem** for on-chain reads.
+
+## Prerequisites
+
+- Stitch MCP configured ([setup guide](https://stitch.withgoogle.com/docs/mcp/setup/))
+- A project `DESIGN.md` (see the `design-md` skill) for token fidelity
+- Vite + React + TypeScript scaffold (`npm create vite@latest`)
+
+## Workflow
+
+1. **Discover MCP prefix** — run `list_tools`, note the Stitch prefix (e.g. `stitch:`).
+2. **Fetch screen** — `[prefix]:get_screen` with project and screen IDs.
+3. **Download assets** — persist HTML/screenshot under `.stitch/designs/{screen}.html` and `.png`.
+4. **Read DESIGN.md** — map `colors.*`, `typography.*`, `spacing.*` to CSS variables in `src/index.css`.
+5. **Generate components** — split into `src/components/`, `src/pages/`, `src/hooks/`.
+6. **Wire data** — use TanStack Query for async fetches; keep presentational components pure.
+
+## HTML → React mapping
+
+| Pattern | Implementation |
+|---------|----------------|
+| Layout grid / flex | Tailwind utilities or CSS modules aligned to DESIGN.md spacing tokens |
+| Cards / panels | `<section>` with tokenized border-radius and elevation fallbacks for forced-colors |
+| Tables | Semantic `<table>` or TanStack Table; never div-only grids for tabular data |
+| Buttons | `<button type="button">` with visible focus ring (preserve browser default unless DESIGN.md defines focus tokens) |
+| Forms | `<label htmlFor>` + `<input id>`; associate errors with `aria-describedby` |
+| Loading | Skeleton components; `aria-busy` on containers during fetch |
+| Wallet connect | Isolate in `WalletProvider`; never embed private keys in generated code |
+
+## DESIGN.md integration
+
+```css
+/* src/index.css — example token bridge */
+:root {
+  --color-primary: /* from DESIGN.md colors.primary */;
+  --font-body: /* typography.body-md.fontFamily */;
+}
+```
+
+Run the design.md linter locally before shipping UI:
+
+```bash
+npx @google/design.md lint DESIGN.md
+```
+
+## Web3 dashboard conventions
+
+- Read-only contract calls via `useReadContract` (viem/wagmi) or ethers `Contract` + TanStack Query `queryFn`.
+- Format token amounts with `formatUnits`; show network name and chain ID in settings footer.
+- Surface transaction errors in plain language; link to block explorer when `txHash` exists.
+- Gas-sensitive flows: batch reads, avoid redundant `eth_call` in render loops.
+
+## File structure
+
+```
+src/
+├── components/     # Presentational UI from Stitch
+├── pages/          # Route-level screens
+├── hooks/          # useQuery wrappers, wallet hooks
+├── lib/            # ABI helpers, formatters
+└── styles/         # Token CSS variables
+```
+
+## Quality checklist
+
+- [ ] WCAG 2.2 AA: contrast from DESIGN.md component pairs passes linter
+- [ ] Keyboard navigable: focus order matches visual order
+- [ ] Responsive: test at 375px and 1280px widths
+- [ ] No secrets in repo: RPC URLs from env (`VITE_*` prefix only for public endpoints)
+- [ ] TypeScript strict: no `any` on contract ABIs
+
+## Stitch docs note
+
+When following links on [stitch.withgoogle.com/docs](https://stitch.withgoogle.com/docs/), use the full `https://stitch.withgoogle.com/docs/...` URL if relative navigation redirects incorrectly.


### PR DESCRIPTION
Add Agent Skill for React + Vite dashboards with TanStack Query, DESIGN.md tokens, and Web3 read patterns. Document docs URL workaround for stitch-skills#69.