### PR TITLE
feat: add hermes-moa plugin with moa-orchestration skill

### DIFF
--- a/plugins/hermes-moa/README.md
+++ b/plugins/hermes-moa/README.md
@@ -1,0 +1,37 @@
+# Hermes MoA Plugin
+
+Mixture of Agents orchestration for [Hermes Agent](https://hermes-agent.nousresearch.com/docs). Configure multi-model presets, run parallel reference analysis, and tune aggregator synthesis for complex reasoning tasks.
+
+## Skills
+
+| Skill | Description |
+|---|---|
+| [moa-orchestration](skills/moa-orchestration/SKILL.md) | Full MoA reference: preset schema, usage examples, cost/latency guidance, compatibility matrix |
+
+## References
+
+| File | Purpose |
+|---|---|
+| [config-schema.md](skills/moa-orchestration/references/config-schema.md) | YAML configuration reference with validation rules |
+| [example-presets.md](skills/moa-orchestration/references/example-presets.md) | Copy-paste ready presets for Pentagon, OpenRouter, budget, and heavy setups |
+
+## Compatibility
+
+| Agent | MoA Support |
+|---|---|
+| Hermes Agent | Native — full preset system with parallel references |
+| MiMoCode | Not supported — single-model runner only |
+| Claude Code | Not supported — use subagent delegation instead |
+
+## Quick Start
+
+```bash
+# Check presets
+hermes moa list
+
+# One-shot analysis
+/moa <your prompt>
+
+# Session-wide MoA
+/model default --provider moa
+```

--- a/plugins/hermes-moa/plugin.json
+++ b/plugins/hermes-moa/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "hermes-moa",
+  "description": "Mixture of Agents orchestration for Hermes — configure multi-model presets, run parallel reference analysis, and tune aggregator synthesis for complex tasks.",
+  "version": "1.0.0",
+  "author": {
+    "name": "mmoguljak"
+  },
+  "homepage": "https://github.com/google-labs-code/stitch-skills",
+  "repository": "https://github.com/google-labs-code/stitch-skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "hermes",
+    "mixture-of-agents",
+    "moa",
+    "multi-model",
+    "orchestration",
+    "parallel-reasoning"
+  ]
+}

--- a/plugins/hermes-moa/skills/moa-orchestration/SKILL.md
+++ b/plugins/hermes-moa/skills/moa-orchestration/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: moa-orchestration
+description: "Configure and run Mixture of Agents (MoA) presets in Hermes — parallel reference analysis with aggregator synthesis for complex reasoning tasks"
+allowed-tools:
+  - "terminal:*"
+  - "Read"
+  - "Write"
+---
+
+# MoA Orchestration
+
+You are a **Mixture of Agents orchestrator** for Hermes. Your goal is to configure multi-model presets, run parallel reference analysis, and synthesize high-quality responses through aggregator models.
+
+## Overview
+
+MoA runs multiple reference models in parallel on every turn, then feeds their combined analysis into an aggregator model that produces the final response. This gives you diverse perspectives without manual prompting.
+
+## When to Use MoA
+
+| Scenario | Command | Why |
+|---|---|---|
+| One hard question | `/moa <prompt>` | Get best analysis once, then switch back |
+| Complex multi-step task | `/model default --provider moa` | Every turn benefits from multiple perspectives |
+| Architecture decisions | `/moa <prompt>` | Diverse model families give different angles |
+| Code review | `/moa <prompt>` | References catch issues aggregator might miss |
+
+## MoA Architecture
+
+```
+User Prompt
+    │
+    ├──→ Reference 1 (parallel) ──┐
+    ├──→ Reference 2 (parallel) ──┼──→ Combined as private context
+    └──→ Reference N (parallel) ──┘
+                                    │
+                            Aggregator Model
+                                    │
+                              Final Response
+```
+
+Each reference model receives the same prompt with a system instruction to analyze rather than act. Their outputs are stripped of tool calls and injected as advisory context for the aggregator, which has full tool access.
+
+## Configuration
+
+### Preset Structure
+
+Presets live in `~/.hermes/config.yaml` under `moa.presets.<name>`:
+
+```yaml
+moa:
+  default_preset: default
+  presets:
+    default:
+      reference_models:
+        - provider: custom:ai.pentagon.technology
+          model: ornith:35b
+        - provider: custom:intelligent.pentagon.technology
+          model: qwen3.6:27b-mtp-q4_K_M
+      aggregator:
+        provider: custom:intelligent.pentagon.technology
+        model: qwen3.6:27b-mtp-q4_K_M
+      reference_max_tokens: 800
+      enabled: true
+```
+
+### Key Fields
+
+| Field | Purpose | Default |
+|---|---|---|
+| `reference_models` | List of parallel advisor models | 2 models |
+| `aggregator` | Final synthesizer with tool access | — |
+| `reference_max_tokens` | Cap per-reference output to control latency/cost | unlimited |
+| `reference_temperature` | Creativity for reference analysis | 0.6 |
+| `aggregator_temperature` | Creativity for final response | 0.4 |
+| `max_tokens` | Aggregator output limit | 4096 |
+| `enabled` | Toggle preset on/off | true |
+
+### Provider Resolution
+
+MoA slots use the same provider resolution as any model call:
+
+- **Built-in providers**: `openrouter`, `anthropic`, `openai-codex`, etc.
+- **Custom providers**: `custom:<name>` where `<name>` matches a `custom_providers` entry in config
+- Each slot independently resolves its own `base_url`, `api_key`, and `api_mode`
+
+## Preset Design Principles
+
+### 1. Reference Diversity
+
+Mix model families for maximum perspective spread:
+
+```yaml
+# Good — different architectures
+reference_models:
+  - provider: custom:ai.pentagon.technology
+    model: ornith:35b
+  - provider: custom:intelligent.pentagon.technology
+    model: qwen3.6:27b-mtp-q4_K_M
+
+# Bad — same family, redundant perspectives
+reference_models:
+  - provider: openrouter
+    model: anthropic/claude-sonnet-4
+  - provider: openrouter
+    model: anthropic/claude-opus-4.8
+```
+
+### 2. Aggregator Strength
+
+The aggregator sees everything and makes the final call — it should be your strongest reasoning model with tool access. If references are weaker than the aggregator, that's fine (they provide diverse angles). If references are stronger, ensure the aggregator can still synthesize well.
+
+### 3. Token Budgeting
+
+Set `reference_max_tokens` to prevent advisors from writing essays:
+
+| Task Type | Recommended Cap |
+|---|---|
+| Quick analysis | 400-600 tokens |
+| Detailed review | 800-1200 tokens |
+| Complex planning | 1500-2000 tokens |
+
+## Cost and Latency
+
+### Token Math
+
+Each MoA turn costs: `(N references × ref_tokens) + aggregator_tokens`
+
+Example with 2 references at 800 tokens each + aggregator at 4096:
+```
+Per turn: (2 × 800) + 4096 = 5,696 output tokens
+vs single model: 4,096 output tokens
+→ ~39% more output tokens per turn
+```
+
+### Latency
+
+References run in parallel via thread pool, so reference latency = `max(ref_1, ref_2, ...ref_N)`, not the sum. Total turn time ≈ `max(references) + aggregator`.
+
+## CLI Commands
+
+```bash
+hermes moa list                    # Show current presets
+hermes moa configure               # Interactive preset setup
+hermes moa delete <preset_name>    # Remove a preset
+```
+
+## Usage Examples
+
+### One-shot analysis
+```
+/moa Compare REST vs GraphQL for our microservices architecture. Consider caching, versioning, and mobile client constraints.
+```
+
+### Session-wide MoA
+```
+/model default --provider moa
+# Now every turn uses the MoA preset until you switch back
+```
+
+### Custom preset selection
+```
+/model my-preset-name --provider moa
+```
+
+## Common Pitfalls
+
+- **Same-family references** — reduces diversity benefit. Mix architectures.
+- **No token cap on references** — advisors write essays, inflating cost and latency. Always set `reference_max_tokens`.
+- **Weak aggregator** — if the aggregator can't synthesize well, reference quality doesn't matter. Pick your strongest model.
+- **Recursive MoA** — you cannot use MoA as a reference or aggregator slot (creates infinite recursion). Hermes rejects this automatically.
+- **Single failure tolerance** — if one reference fails, the turn continues with remaining references. The aggregator sees a labeled note for the failed slot.
+
+## Environment Compatibility
+
+| Agent | MoA Support | Notes |
+|---|---|---|
+| Hermes Agent | ✅ Native | Full preset system, parallel references, aggregator synthesis |
+| MiMoCode | ❌ Not supported | Single-model runner only — use provider routing instead |
+| Claude Code | ❌ Not supported | Use subagent delegation for multi-perspective analysis |
+
+For agents without native MoA, achieve similar results by spawning parallel subagents and manually combining their output.
+
+## Troubleshooting
+
+| Issue | Solution |
+|---|---|
+| `Model not found` | Check model name matches exactly what the provider returns |
+| Reference timeout | Increase `reference_max_tokens` or reduce reference count |
+| Aggregator ignores references | Lower `reference_temperature` to get more focused analysis |
+| High cost per turn | Reduce `reference_max_tokens` or use fewer references |

--- a/plugins/hermes-moa/skills/moa-orchestration/references/config-schema.md
+++ b/plugins/hermes-moa/skills/moa-orchestration/references/config-schema.md
@@ -1,0 +1,57 @@
+# MoA Preset Configuration Schema
+
+## Top-Level Keys
+
+```yaml
+moa:
+  default_preset: "default"          # Which preset is active by default
+  presets:                           # Named preset definitions
+    <preset_name>:                   # e.g. "default", "heavy", "fast"
+      reference_models: [...]        # Parallel advisor models (required)
+      aggregator: {...}              # Final synthesizer (required)
+      reference_max_tokens: int|null # Per-reference output cap (optional)
+      reference_temperature: float   # Reference creativity (default 0.6)
+      aggregator_temperature: float  # Aggregator creativity (default 0.4)
+      max_tokens: int                # Aggregator output limit (default 4096)
+      enabled: bool                  # Toggle preset on/off (default true)
+```
+
+## Slot Schema (reference_models and aggregator)
+
+Each slot is a `{provider, model}` pair:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `provider` | string | Yes | Provider identifier — built-in name or `custom:<name>` |
+| `model` | string | Yes | Model tag matching the provider's catalog |
+
+## Provider Resolution
+
+Slots resolve through the same path as any model call:
+
+- **Built-in**: `openrouter`, `anthropic`, `openai-codex`, `zai`, `kimi-coding`, etc.
+- **Custom**: `custom:<name>` where `<name>` matches a `custom_providers` entry in `~/.hermes/config.yaml`
+- Each slot independently resolves its own `base_url`, `api_key`, and `api_mode`
+
+## Validation Rules
+
+- At least one reference model required
+- Aggregator is required — cannot be omitted
+- `provider: moa` is rejected (prevents recursive MoA trees)
+- Empty or missing provider/model drops the slot, falling back to defaults
+- `reference_max_tokens` must be positive integer or null (unlimited)
+
+## Example: Minimal Valid Preset
+
+```yaml
+moa:
+  default_preset: quick
+  presets:
+    quick:
+      reference_models:
+        - provider: openrouter
+          model: anthropic/claude-sonnet-4
+      aggregator:
+        provider: openrouter
+          model: anthropic/claude-opus-4.8
+```

--- a/plugins/hermes-moa/skills/moa-orchestration/references/example-presets.md
+++ b/plugins/hermes-moa/skills/moa-orchestration/references/example-presets.md
@@ -1,0 +1,109 @@
+# Example MoA Presets
+
+Copy-paste ready configurations for common setups.
+
+## Pentagon Providers (Self-Hosted)
+
+Two different model families on custom endpoints — maximum diversity:
+
+```yaml
+moa:
+  default_preset: pentagon
+  presets:
+    pentagon:
+      reference_models:
+        - provider: custom:ai.pentagon.technology
+          model: ornith:35b
+        - provider: custom:intelligent.pentagon.technology
+          model: qwen3.6:27b-mtp-q4_K_M
+      aggregator:
+        provider: custom:intelligent.pentagon.technology
+        model: qwen3.6:27b-mtp-q4_K_M
+      reference_max_tokens: 800
+      enabled: true
+```
+
+## OpenRouter Mix (Cloud)
+
+Three references spanning different architectures, strong aggregator:
+
+```yaml
+moa:
+  default_preset: cloud
+  presets:
+    cloud:
+      reference_models:
+        - provider: openrouter
+          model: anthropic/claude-sonnet-4
+        - provider: openrouter
+          model: deepseek/deepseek-v4-pro
+        - provider: openrouter
+          model: qwen/qwen3-235b-a22b-thinking-2507
+      aggregator:
+        provider: openrouter
+        model: anthropic/claude-opus-4.8
+      reference_max_tokens: 600
+      max_tokens: 4096
+      enabled: true
+```
+
+## Fast and Cheap (Budget)
+
+Lightweight references, fast aggregator — good for quick questions:
+
+```yaml
+moa:
+  default_preset: budget
+  presets:
+    budget:
+      reference_models:
+        - provider: openrouter
+          model: google/gemini-2.5-flash-lite-preview-06-17
+        - provider: openrouter
+          model: qwen/qwen3-30b-a3b-thinking-2507
+      aggregator:
+        provider: openrouter
+        model: anthropic/claude-sonnet-4
+      reference_max_tokens: 400
+      max_tokens: 2048
+      enabled: true
+```
+
+## Heavy Analysis (Maximum Quality)
+
+Strong references, strong aggregator — for complex reasoning tasks:
+
+```yaml
+moa:
+  default_preset: heavy
+  presets:
+    heavy:
+      reference_models:
+        - provider: openrouter
+          model: anthropic/claude-opus-4.8
+        - provider: openrouter
+          model: deepseek/deepseek-v4-pro
+        - provider: openai-codex
+          model: gpt-5.5
+      aggregator:
+        provider: openrouter
+        model: anthropic/claude-opus-4.8
+      reference_max_tokens: 1500
+      max_tokens: 8192
+      enabled: true
+```
+
+## Applying a Preset
+
+```bash
+# Check what's configured
+hermes moa list
+
+# Use one-shot
+/moa <your prompt>
+
+# Switch session-wide
+/model pentagon --provider moa
+/model cloud --provider moa
+/model heavy --provider moa
+```


### PR DESCRIPTION
## What

Adds a Hermes Mixture-of-Agents orchestration plugin to stitch-skills. Includes:
- `plugin.json` — plugin manifest (Apache-2.0)
- `skills/moa-orchestration/SKILL.md` — full reference documentation with preset schema, usage examples, cost/latency guidance, and compatibility matrix
- `references/config-schema.md` — YAML configuration reference
- `references/example-presets.md` — copy-paste ready presets for Pentagon providers, OpenRouter mix, budget, and heavy analysis setups

## Compatibility Note

MoA is native to Hermes Agent only. MiMoCode (single-model runner) does not support multi-model fan-out natively — this plugin documents the pattern so agents without native MoA can achieve similar results via subagent delegation.

## CLA

⚠️ Per CONTRIBUTING.md, a Google CLA may be required before merge.