### PR TITLE
Fix download script saving HTTP error pages as assets

### DIFF
--- a/plugins/stitch-build/skills/remotion/scripts/download-stitch-asset.sh
+++ b/plugins/stitch-build/skills/remotion/scripts/download-stitch-asset.sh
@@ -21,12 +21,11 @@ mkdir -p "$OUTPUT_DIR"
 echo "Downloading from: $DOWNLOAD_URL"
 echo "Saving to: $OUTPUT_PATH"
 
-# Use curl with follow redirects and authentication handling
-curl -L -o "$OUTPUT_PATH" "$DOWNLOAD_URL"
-
-if [ $? -eq 0 ]; then
+# Use curl with follow redirects; -f fails on HTTP errors so an error
+# response (e.g. an expired signed URL) is not saved as the asset
+if curl -L -f -o "$OUTPUT_PATH" "$DOWNLOAD_URL"; then
   echo "✓ Successfully downloaded to $OUTPUT_PATH"
-  
+
   # Display file size for verification
   if command -v stat &> /dev/null; then
     FILE_SIZE=$(stat -f%z "$OUTPUT_PATH" 2>/dev/null || stat -c%s "$OUTPUT_PATH" 2>/dev/null)
@@ -34,5 +33,6 @@ if [ $? -eq 0 ]; then
   fi
 else
   echo "✗ Download failed"
+  rm -f "$OUTPUT_PATH"
   exit 1
 fi


### PR DESCRIPTION

 In `plugins/stitch-build/skills/remotion/scripts/download-stitch-asset.sh`, `curl` runs without `-f`, so an HTTP error response (e.g. an expired signed URL returning 403 XML) gets saved as the output `.png` and the script reports a successful download.

  The `else` "Download failed" branch is also dead code — with `set -e`, the script exits before the exit-code check runs.

  ## Fix

  - Add `-f` so curl fails on HTTP errors instead of saving the error body
  - Move curl into an `if` condition so the failure branch is reachable under `set -e`
  - Remove the partial output file on failure

  ## Testing

  Verified against a local HTTP server:

  - 403 response: exits 1, no output file left behind (before: exit 0, XML error page saved as `.png`)
  - 200 response: downloads correctly, exits 0
  - No-args usage message still works
