### PR TITLE
docs: fix shadcn skill links

### DIFF
--- a/plugins/stitch-build/skills/shadcn-ui/README.md
+++ b/plugins/stitch-build/skills/shadcn-ui/README.md
@@ -241,8 +241,8 @@ Check your `tsconfig.json` includes path aliases:
 
 ## Contributing
 
-Contributions to improve this skill are welcome! See the root [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+Contributions to improve this skill are welcome! See the root [CONTRIBUTING.md](../../../../CONTRIBUTING.md) for guidelines.
 
 ## License
 
-See [LICENSE](../../LICENSE) in the repository root.
+See [LICENSE](../../../../LICENSE) in the repository root.


### PR DESCRIPTION
## Summary

- Fix the `shadcn-ui` skill's links to the repository-level contribution guide and license.

## Root cause

`plugins/stitch-build/skills/shadcn-ui/README.md` is four directories below the repository root, but both links only traversed two levels. GitHub therefore resolved them to paths that do not exist beneath `plugins/stitch-build/`.

## Validation

- Resolved both modified relative links against the checkout and confirmed the root `CONTRIBUTING.md` and `LICENSE` exist.
- Ran a repository-wide Markdown relative-link scan: 0 broken relative links.
- Ran `git diff --check`.

## Contributor agreement

This repository requires the contributor account to complete the Google CLA before merge. That agreement must be completed by the account owner.
