### PR TITLE
fix(react-components): match full hex color range in validate.js

### DIFF
--- a/plugins/stitch-build/skills/react-components/scripts/validate.js
+++ b/plugins/stitch-build/skills/react-components/scripts/validate.js
@@ -18,7 +18,7 @@ import swc from '@swc/core';
 import fs from 'node:fs';
 import path from 'node:path';
 
-const HEX_COLOR_REGEX = /#[0-9A-Fa-f]{6}/;
+const HEX_COLOR_REGEX = /#[0-9A-Fa-f]{3,8}\b/;
 
 async function validateComponent(filePath) {
   const code = fs.readFileSync(filePath, 'utf-8');


### PR DESCRIPTION

  ## What
  react-components' `validate.js` used `/#[0-9A-Fa-f]{6}/` for hex-color detection an exact 6-digit match with no word boundary.

  ## Fix
  Short-form hex codes (`#fff`, `#ffff`), both valid CSS/Tailwind values, went completely undetected by the "hardcoded hex" check. Changed the regex to  `/#[0-9A-Fa-f]{3,8}\b/`, matching the react-native validator's existing (correct) pattern.

  ## Testing
  Ran the validator against fixture components locally: a component using `bg-[#fff]`/`text-[#112233]` is now correctly flagged, and a clean component using only Tailwind utility classes still passes.