### PR TITLE
fix(validate): don't crash on missing/bad file argument

### DIFF
--- a/plugins/stitch-build/skills/react-components/scripts/validate.js
+++ b/plugins/stitch-build/skills/react-components/scripts/validate.js
@@ -21,9 +21,13 @@ import path from 'node:path';
 const HEX_COLOR_REGEX = /#[0-9A-Fa-f]{6}/;
 
 async function validateComponent(filePath) {
-  const code = fs.readFileSync(filePath, 'utf-8');
-  const filename = path.basename(filePath);
+  if (!filePath) {
+    console.error("Usage: node validate.js <path-to-component>");
+    process.exit(1);
+  }
   try {
+    const code = fs.readFileSync(filePath, 'utf-8');
+    const filename = path.basename(filePath);
     const ast = await swc.parse(code, { syntax: "typescript", tsx: true });
     let hasInterface = false;
     let tailwindIssues = [];
@@ -70,7 +74,7 @@ async function validateComponent(filePath) {
       process.exit(1);
     }
   } catch (err) {
-    console.error("❌ PARSE ERROR:", err.message);
+    console.error("❌ ERROR:", err.message);
     process.exit(1);
   }
 }

--- a/plugins/stitch-build/skills/react-native/scripts/validate.js
+++ b/plugins/stitch-build/skills/react-native/scripts/validate.js
@@ -23,9 +23,13 @@ const RGBA_COLOR_REGEX = /^rgba?\(\s*\d/;
 const HTML_ELEMENTS = ['div', 'span', 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'img', 'button', 'a', 'input', 'ul', 'ol', 'li', 'section', 'header', 'footer', 'nav', 'main'];
 
 async function validateComponent(filePath) {
-  const code = fs.readFileSync(filePath, 'utf-8');
-  const filename = path.basename(filePath);
+  if (!filePath) {
+    console.error("Usage: node validate.js <path-to-component>");
+    process.exit(1);
+  }
   try {
+    const code = fs.readFileSync(filePath, 'utf-8');
+    const filename = path.basename(filePath);
     const ast = await swc.parse(code, { syntax: "typescript", tsx: true });
     let hasInterface = false;
     let hasExportedInterface = false;
@@ -112,7 +116,7 @@ async function validateComponent(filePath) {
       process.exit(1);
     }
   } catch (err) {
-    console.error("PARSE ERROR:", err.message);
+    console.error("ERROR:", err.message);
     process.exit(1);
   }
 }


### PR DESCRIPTION
 ## What
  Both react-components and react-native
  `scripts/validate.js` called `fs.readFileSync` before the try block with no argv[2] check.

  ## Fix
  with a nonexistent path, threw an unhandled exception (raw Node stack trace) instead of a clean error. Added a usage-message
  guard for the missing-argument case and moved the file read inside the existing try/catch.

  ## Testing
  Verified locally: no-arg and bad-path invocations now print a clean message and exit 1 in both copies; both gold-standard examples still validate successfully.