### PR TITLE
feat(stitch-design): add Angular support and auth-gated documentation

### DIFF
--- a/plugins/stitch-design/skills/code-to-design/SKILL.md
+++ b/plugins/stitch-design/skills/code-to-design/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: stitch::code-to-design
 description: >-
-  Convert frontend code (Vite, React, etc.) to a Stitch Design by chaining
-  static HTML extraction, design system extraction, and file upload. **ALWAYS** use this skill when the user's intent is to move existing web apps or React components into Stitch (e.g., requests to "save", "migrate", or "upload"). You must use this skill even for simple "save" operations, as it is the only way to ensure the design system is extracted and assets are properly linked.
+  Convert frontend code (Vite, React, Angular, Vue, etc.) to a Stitch Design by chaining
+  static HTML extraction, design system extraction, and file upload. **ALWAYS** use this skill when the user's intent is to move existing web apps or React/Angular/Vue components into Stitch (e.g., requests to "save", "migrate", or "upload"). You must use this skill even for simple "save" operations, as it is the only way to ensure the design system is extracted and assets are properly linked.
 allowed-tools:
   - "stitch*:*"
   - "Bash"
@@ -13,11 +13,11 @@ allowed-tools:
 
 # Code to Design
 
-Transform your existing frontend code into a Stitch Design so you can iterate and improve it using Stitch.
+Transform your existing frontend code (React + Vite, Next.js, Angular, Vue, etc.) into a Stitch Design so you can iterate and improve it using Stitch.
 
 This skill orchestrates three other skills in sequence:
-1. `extract-static-html`: Extract a single self-contained HTML file from your build output.
-2. `extract-design-md`: Analyze the source code to create a design system (DESIGN.md).
+1. `extract-static-html`: Extract a single self-contained HTML file from your build output or running dev server (e.g., Vite dev server or Angular CLI `ng serve`).
+2. `extract-design-md`: Analyze the source code (including Angular `angular.json`, external `.html` templates, theme files, and components) to create a design system (DESIGN.md).
 3. `upload-to-stitch`: Upload that HTML file and the design system to your Stitch project.
 
 ## Workflow
@@ -26,7 +26,7 @@ Follow these steps to convert your existing code.
 
 ### Prerequisites
 
-- A built web application directory containing `index.html` and assets.
+- A running local dev server (e.g. `npm run dev`, `ng serve`) OR a built web application directory containing `index.html` and assets.
 - Target Stitch `projectId` (use `list_projects` if unknown).
 
 ### Steps

--- a/plugins/stitch-design/skills/extract-design-md/references/angular.md
+++ b/plugins/stitch-design/skills/extract-design-md/references/angular.md
@@ -16,13 +16,15 @@ global themes and component-scoped styles.
 3. **`src/theme.scss` / `src/theme/`** — Explicit theme directory. Custom
    Material/component palettes.
 
-4. **`tailwind.config.js`** (if Tailwind) — Same extraction as React.
+4. **Tailwind Config (`tailwind.config.js` or Tailwind v4 `@theme {}`)** — For Tailwind v3, read `tailwind.config.js`. For Tailwind v4, inspect `@theme {}` blocks, `@custom-variant`, and `@plugin 'tailwindcss-primeui'` in your global CSS/SCSS (e.g. `src/styles.css` or `src/assets/tailwind.css`) for CSS custom property tokens (`--color-*`, `--font-*`, `--text-*`, `--breakpoint-*`).
 
 5. **`src/app/app.component.scss`** — Root component styles, reveals global
    layout patterns.
 
 6. **Component `.scss` / `.css` files** — Co-located styles (ViewEncapsulation
    scoped by default).
+
+7. **External Template `.html` files (`src/app/**/*.component.html`)** — Essential for Angular 17+ standalone components using Tailwind CSS utility classes (`bg-*`, `text-*`, `p-*`, `rounded-*`) or structural class bindings (`[ngClass]`, `[class.*]`). Always inspect `.html` templates when styling uses utility classes.
 
 ## Angular Material Theme Extraction
 
@@ -99,11 +101,17 @@ component styles:
 ## PrimeNG / Nebular / NG-ZORRO
 
 If component libraries are used:
-- **PrimeNG**: Theme SCSS in `node_modules/primeng/resources/themes/` —
-  look for custom theme or `styles.scss` overrides.
+- **PrimeNG (v17/v18/v19+)**: Look for modern theme configuration in `src/app.config.ts` (e.g., `providePrimeNG({ theme: { preset: Aura, options: { darkModeSelector: '.app-dark' } } })`). Check for Tailwind v4 integration via `@plugin 'tailwindcss-primeui'` in CSS assets. Inspect CSS custom properties defined by PrimeNG tokens (`--primary-color`, `--surface-*`).
 - **Nebular**: `nb-theme()` in `styles.scss` with custom theme object.
 - **NG-ZORRO (Ant Design for Angular)**: `ng-zorro-antd.less` variables
   or custom theme config in `angular.json`.
+
+## Modern Angular (v17 - v19) Standalone Components & Control Flow
+
+In modern Angular repositories:
+- **Standalone Components (`@Component({ standalone: true })`)**: Components import their own dependencies directly without NgModules. Inspect `templateUrl` and `styleUrl(s)` in component metadata to locate the template and style files.
+- **Control Flow (`@if`, `@for`, `@switch`)**: Notice how conditional layouts and lists are structured in `.html` templates when analyzing component density and spacing rules.
+- **Signals & Zoneless (`signal()`, `input()`, `computed()`, `provideZonelessChangeDetection()`)**: Dynamic styling or theme toggling is often driven by signals bound to `[class.dark]` or custom CSS classes in templates. Notice `app.config.ts` for app-wide providers.
 
 ## Responsive Patterns
 

--- a/plugins/stitch-design/skills/extract-static-html/SKILL.md
+++ b/plugins/stitch-design/skills/extract-static-html/SKILL.md
@@ -86,6 +86,8 @@ Launches headless Chrome, captures the fully rendered DOM, and produces a self-c
 | `--remove-fixed` | `false` | Remove fixed/sticky elements (cookie banners, chat widgets) |
 | `--full-height` | `false` | Resize viewport to full scroll height |
 | `--title` | — | Override page title |
+| `--auth-script` | — | Path to a JS/TS module that exports a default `async (page) => void` function for authentication |
+| `--inline-canvas` | `false` | Convert `<canvas>` elements (ECharts, Chart.js, D3) to base64 `<img>` tags |
 
 ### What It Does Automatically
 
@@ -102,6 +104,7 @@ Launches headless Chrome, captures the fully rendered DOM, and produces a self-c
 | :--- | :--- |
 | **React + Vite** | Works out of the box. `--wait 1000`. |
 | **Next.js** | `--wait 3000` for SSR hydration. URL: `http://localhost:3000`. `<img srcset>` from `/_next/image` is auto-inlined as base64. |
+| **Angular (@angular/cli / v17+)** | Works out of the box with `ng serve` (default URL: `http://localhost:4200`). `--wait 2000` for Angular Material / PrimeNG animation hydration and lazy-loaded routes. |
 | **Vue / Nuxt** | Works out of the box. |
 | **Svelte / SvelteKit** | Works out of the box. |
 | **Storybook** | Use story URL: `--url http://localhost:6006/?path=/story/...` |
@@ -116,8 +119,60 @@ Launches headless Chrome, captures the fully rendered DOM, and produces a self-c
 | Next.js `/_next/image` not inlined | Ensure the dev server is running when snapshot runs — the script fetches optimized images from the running server. |
 | Dark mode not applied | `--html-class dark` |
 | Cookie banner in output | `--remove-fixed` |
-| Page requires login | Use the Static Fallback (appendix below) |
+| Page requires login | Use `--auth-script ./auth.ts` (see Auth-Gated Pages below) |
+| Charts/graphs show as blank boxes | Use `--inline-canvas` to serialize `<canvas>` to base64 `<img>` |
 | `Cannot find module 'puppeteer'` | `npm install -g puppeteer` |
+
+### Auth-Gated Pages
+
+For apps with login guards (Vue Router `beforeEach`, React `ProtectedRoute`, etc.), create a small auth script that runs in the Puppeteer session:
+
+```ts
+// auth-myapp.ts
+import type { Page } from 'puppeteer';
+
+export default async function authenticate(page: Page) {
+  // Example 1: Fill and submit a login form
+  await page.type('#username', 'admin');
+  await page.type('#password', 'password123');
+  await page.click('#login-button');
+  await page.waitForNavigation({ waitUntil: 'networkidle2' });
+
+  // Example 2: Inject cookies/localStorage directly
+  // await page.evaluate(() => {
+  //   localStorage.setItem('token', 'mock-jwt-token');
+  // });
+
+  // Example 3: Call the app's own login API via module injection (Vue/Vite)
+  // await page.evaluate(() => {
+  //   return new Promise((resolve) => {
+  //     const script = document.createElement('script');
+  //     script.type = 'module';
+  //     script.textContent = `
+  //       import { useUserStore } from '/src/store/modules/user.ts';
+  //       import { fetchLogin } from '/src/api/auth.ts';
+  //       const res = await fetchLogin({ userName: 'Admin', password: '123456' });
+  //       useUserStore().setToken(res.token, res.refreshToken);
+  //       window.dispatchEvent(new CustomEvent('auth-done'));
+  //     `;
+  //     document.head.appendChild(script);
+  //     window.addEventListener('auth-done', () => resolve(true), { once: true });
+  //   });
+  // });
+}
+```
+
+Then use it:
+```bash
+npx tsx <SKILL_DIR>/scripts/snapshot.ts \
+  --url http://localhost:5173/#/dashboard \
+  --output .stitch/dashboard.html \
+  --auth-script ./auth-myapp.ts \
+  --inline-canvas \
+  --wait 5000
+```
+
+The script navigates to the `--url` first (which may redirect to login), runs your auth function, then **re-navigates** to the original `--url` with the authenticated session.
 
 ***
 


### PR DESCRIPTION
## Summary of Changes
- **`code-to-design`**: Explicitly include Angular in skill description, prerequisites, and file discovery checklist. Add live development server workflow (`ng serve` / `npm run dev`) as standard input for HTML snapshotting.
- **`extract-design-md`**: Expand `references/angular.md` with rules for Tailwind CSS v4 (`@theme {}`), PrimeNG Aura presets in `app.config.ts`, external component templates (`*.component.html`), and modern Angular v17–v21 standalone/zoneless patterns.
- **`extract-static-html`**: Document Angular CLI (`http://localhost:4200`, `--wait 2000`) in *Framework Notes*, and add comprehensive documentation and code examples for auth-gated pages (`--auth-script`).

All changes were tested using real app codes